### PR TITLE
Print error for invalid grafana directory

### DIFF
--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -303,6 +303,9 @@ def main():
                             stream_handler
                             ]
                         )
+    if not os.path.isdir(args.grafana_home_path):
+        logging.error('Invalid grafana path: {}'.format(args.grafana_home_path))
+        sys.exit(1)
 
     cbcollects = get_cbcollect_dirs()
     config = parse_couchbase_log(cbcollects[0])


### PR DESCRIPTION
Prior to this change specifying an invalid grafana-home path would
result in no error and promtimer returning.

With this change an error is printed.

$ ~/promtimer/bin/promtimer --grafana-home \
  /usr/local/Cellar/grafana/7.2.0/share/grafana/ \
  --prometheus ~/prometheus/prometheus
Invalid grafana path: /usr/local/Cellar/grafana/7.2.0/share/grafana/