### PR TITLE
Provide error messages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,12 +15,10 @@
 ## Grafana Integration
 
 #### Guess where Grafana is when homepath not provided
-#### Provide friendly error message if Grafana can't be found
 
 ## Prometheus Integration
 
 #### Support accessing Prometheus instances other than from cbcollects
-#### Provide friendly error message if Prometheus can't be found
 
 ## Code
 


### PR DESCRIPTION
Rather than relying on decoding python backtraces we'll provide error
messages for:

* prometheus executable not found
* no zipped bundles or cbcollect_info directories found