### PR TITLE
Add timer_lag_recorder stats graph

### DIFF
--- a/dashboards/ns-server-dashboard.json
+++ b/dashboards/ns-server-dashboard.json
@@ -247,6 +247,18 @@
           "_base": "target"
         }
       ]
+    },
+    {
+      "title": "check_time message delay",
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "{data-source-name}",
+          "expr": "histogram_quantile(0.999, irate(cm_timer_lag_seconds_bucket[5m]))",
+          "legendFormat": "{data-source-name} {{name}}",
+          "_base": "target"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The timer_lag_recorder sends itself a message to be delivered one second
later. When the message is received the difference in the time vs the
expected time (Lag) is saved. This change provides a histogram_quantile
of these lags. It serves as an indicator of when erlang scheduling is
affected to the point where messages are not getting delivered in a
timely manner. The ns_server.debug.log can be examine for messages of
this type:

timer_lag_recorder:report_missed_msgs:47]Skipped 1 'check_time' messages
timer_lag_recorder:report_missed_msgs:47]Skipped 2 'check_time' messages
timer_lag_recorder:report_missed_msgs:47]Skipped 5 'check_time' messages
timer_lag_recorder:report_missed_msgs:47]Skipped 1 'check_time' messages