### PR TITLE
README.md: Add simplified macOS grafana path

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The `path-to-grafana-shared-config-home` is what is known in Grafana terminology
 "homepath". This is the out-of-the-box Grafana shared config path. On brew-installed
 Grafana on Macs this is something like:
 
-    /usr/local/Cellar/grafana/x.y.z/share/grafana
+    /usr/local/share/grafana
 
 On linux systems the homepath should usually be:
 


### PR DESCRIPTION
Homebrw maintains a convenience symlink in /usr/local/share to the specific grafana version:

    $ ls -l /usr/local/share/grafana
    lrwxr-xr-x  1 dave  admin  37 19 Feb 15:33 /usr/local/share/grafana -> ../Cellar/grafana/7.4.2/share/grafana