### PR TITLE
Update Promtimer description and TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 [Mortimer](https://github.com/couchbaselabs/mortimer) is a convenient 
 tool that can be used to display statistics grabbed from Couchbase collected 
-log bundles (cbcollects). With the move to use Prometheus for stats
-storage and management, Mortimer will no longer work. It would be possible
-to extract stats from cbcollects and adapt them to work with Mortimer, but
-this project attempts somthing different: use Prometheus itself and Grafana
-to allow easy, powerful browsing of Prometheus metrics (stats) available in 
-cbcollects.
+log bundles (cbcollects). With the move to Prometheus for stats storage and
+management, Mortimer was temporarily rendered unusable. It has since been
+enabled to access Prometheus stats.
 
-If you've already installed, here are a some quick links you might be
+**Promtimer** provides an alternative to Mortimer, using Prometheus itself and Grafana
+to allow for easy and powerful browsing of Prometheus metrics (stats) available in 
+cbcollects. The preset dashboards also allow for easier discoverability of
+statistics and allow cbcollects to be analyzed without prior knowledge of stat names.
+
+If you've already installed **Promtimer**, here are a some quick links you might be
 interested in:
 * [Dashboards README](dashboards/README.md)
-* [Todos](TODO.md)
+* [List of TODOs](TODO.md)
 
 ## Idea
 Promtimer:
@@ -42,7 +44,7 @@ instructions on the Prometheus website are comprehensive. You don't actually
 need to install Prometheus, you just need the binary. [Downloading](https://prometheus.io/download/)
 and unzipping the pre-compiled binaries for your platform is sufficient.
 
-If you're on Mac,`brew` is convenient:
+If you're on Mac, `brew` is convenient:
 
     brew install prometheus
 
@@ -67,7 +69,7 @@ To get Promtimer, clone this repo locally:
 
     git clone https://github.com/couchbaselabs/promtimer.git
 
-As to cbcollects, you probably wouldn't be reading this if you didn't already
+As for cbcollects, you probably wouldn't be reading this if you didn't already
 have them. 
 
 ## How to Use Promtimer
@@ -136,4 +138,4 @@ rm -rf .promtimer
 
 ## Want to Help?
 
-Awesome! See the [list of todos](TODO.md).
+Awesome! See the [list of TODOs](TODO.md).

--- a/TODO.md
+++ b/TODO.md
@@ -1,29 +1,31 @@
-# Todos
+# TODOs
 
 ## Dashboards
 
-#### Add KV related dashboard(s)
-#### Add query related dashboard(s)
-#### Add indexing related dashboard(s)
-#### Add fts related dashboard(s)
-#### Add analytics related dashboard(s)
-#### Add eventing related dashboard(s)
-#### Document dashboard meta model
-#### Add support for different panel configurations
-#### Add support for scope and collection templating
+### General
+
+* Document dashboard meta model
+* Add support for scope and collection templating
+
+### Tiered Dashboards
+
+*An example of tiered dashboards is the KV Cluster / Node / Node & Bucket
+dashboards, breaking down the stats by level of detail.*
+
+* Add query related dashboard(-s)
+* Add indexing related dashboard(-s)
+* Add fts related dashboard(-s)
+* Add analytics related dashboard(-s)
+* Add eventing related dashboard(-s)
 
 ## Grafana Integration
 
-#### Guess where Grafana is when homepath not provided
+* Guess where Grafana is when homepath not provided
 
 ## Prometheus Integration
 
-#### Support accessing Prometheus instances other than from cbcollects
+* Support accessing Prometheus instances other than from cbcollects
 
 ## Code
 
-#### Better comments in the code
-
-
-
-
+* Improve comments in the code


### PR DESCRIPTION
Updated the readme description since Mortimer does now support Prometheus stat viewing; now describing Promtimer as a useful alternative in terms of ease of use and stat discoverability.

Updated the TODOs list to remove done items and formatted in a way that should hopefully guide better contributions.