### PR TITLE
Increase loopback-delta to 10m in order to...

### DIFF
--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -143,6 +143,7 @@ def start_prometheuses(cbcollects, base_port, log_dir):
                 '--storage.tsdb.path', path.join(cbcollect, 'stats_snapshot'),
                 '--storage.tsdb.no-lockfile',
                 '--storage.tsdb.retention.time', '10y',
+                '--query.lookback-delta', '600s',
                 '--web.listen-address', listen_addr]
         logging.info('starting prometheus server {} (on {} against {}; logging to {})'
                      .format(i, listen_addr, path.join(cbcollect, 'stats_snapshot'),


### PR DESCRIPTION
...support decimation intervals up to 10 minutes.

This change sets the --query.lookback-delta to 600 seconds when starting
prometheus. This is needed to support 1 sample per 10 minutes. The
default value is 300 seconds which leads to samples not being found.
https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness