### PR TITLE
Open grafana in new browser tab if possible.

### DIFF
--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -281,7 +281,7 @@ def open_browser(grafana_http_port):
     try:
         # For some reason this sometimes throws an OSError with no
         # apparent side-effects. Probably related to forking processes
-        webbrowser.open_new(url)
+        webbrowser.open_new_tab(url)
     except OSError:
         logging.error("Hit `OSError` opening web browser")
         pass


### PR DESCRIPTION
I find the current behavior of opening grafana in a new window annoying and prefer when the dashboard opens in a separate tab. But I understand that this is a matter of tastes. So feel free to disregard.