### PR TITLE
Retry getting annotations for http errors

### DIFF
--- a/promtimer/util.py
+++ b/promtimer/util.py
@@ -99,7 +99,7 @@ def execute_request(url, path, method='GET', data=None,
                                              headers=headers)
             response = opener.open(request)
             return response
-        except urllib.request.URLError as ue:
+        except (urllib.request.URLError, urllib.request.HTTPError):
             logging.debug('Attempting connection to {}, '
                           'retrying... {} retries left'.format(url, retries))
             retries -= 1


### PR DESCRIPTION
Ensure we retry getting annotations if we get an HTTP error (ie a non-200 status code).

On my machine the first time I start promtimer on a set of data it opens a webpage and then throws an exception due to getting a 404 for the annotations. There's already retry logic so I've just made it catch this exception as well.