### PR TITLE
Don't add onto url on retry

### DIFF
--- a/promtimer/util.py
+++ b/promtimer/util.py
@@ -88,9 +88,9 @@ def execute_request(url, path, method='GET', data=None,
     opener = urllib.request.build_opener(*handlers)
     if not path.startswith('/'):
         path = '/' + path
+    url = '{}{}'.format(url, path)
     while retries >= 0:
         try:
-            url = '{}{}'.format(url, path)
             if headers is None:
                 headers = {}
             request = urllib.request.Request(url=url,


### PR DESCRIPTION
Prior to this change when trying to get annotations a retry would lead
to the url getting appended with the same path info.

Potential annotations: 1
http://localhost:13300/api/annotations
http://localhost:13300/api/annotations/api/annotations
http://localhost:13300/api/annotations/api/annotations/api/annotations
...