### PR TITLE
bucket-overview: Add KV response error rate panel

### DIFF
--- a/dashboards/bucket-overview.json
+++ b/dashboards/bucket-overview.json
@@ -70,6 +70,18 @@
       ]
     },
     {
+      "title": "$bucket: KV response error rates",
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "{data-source-name}",
+          "expr": "sum(irate(kv_total_resp_errors{bucket=\"$bucket\"}[1m]))",
+          "legendFormat": "{data-source-name} sum(irate(kv_total_resp_errors[1m]))",
+          "_base": "target"
+        }
+      ]
+    },
+    {
       "title": "$bucket: 90th percentile GET latency",
       "_base": "panel",
       "_targets": [


### PR DESCRIPTION
This is valuable when looking at KV operation rates, as the base kv_ops graph shows the number of /requests/, not necessarily how many were successful or instead errored.