### PR TITLE
AV-51166: Make Promtimer work with Capella clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.iml
 *.iml~
 promtimer/__pycache__/
+.promtimer

--- a/data-source.yaml
+++ b/data-source.yaml
@@ -31,6 +31,7 @@ datasources:
     editable: true
     jsonData:
       timeInterval: 1s
+      tlsSkipVerify: true
     # <string> json object of data that will be encrypted.
     secureJsonData:
       # <string> basic auth password

--- a/data-source.yaml
+++ b/data-source.yaml
@@ -21,7 +21,7 @@ datasources:
     # if not specified will be generated automatically
     uid: {data-source-name}
     # <string> url
-    url: http://{data-source-host}:{data-source-port}/{data-source-path}
+    url: {data-source-host}:{data-source-port}/{data-source-path}
     # <bool> enable/disable basic auth
     basicAuth: {data-source-basic-auth}
     # <string> basic auth username

--- a/promtimer/cbstats.py
+++ b/promtimer/cbstats.py
@@ -423,8 +423,8 @@ class ServerNode(Source):
                                        self._user, self._password)
 
     @staticmethod
-    def get_stats_sources(cluster, user, password, nodes=None):
-        secure = re.match('https://', cluster, re.IGNORECASE)
+    def get_stats_sources(cluster, user, password):
+        secure = cluster.startswith("https://")
         result = []
         try:
             response = util.execute_request(cluster, 'pools/default/nodeServices',
@@ -447,7 +447,7 @@ class ServerNode(Source):
     def get_stats_sources_from_nodes(nodes, user, password):
         result = []
         for node in nodes:
-            secure = re.match('https://', node, re.IGNORECASE)
+            secure = node.startswith("https://")
             response = util.execute_request(node, 'nodes/self',
                                             username=user, password=password)
             nodes_self = json.loads(response.read())

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -220,6 +220,9 @@ def main():
                         help='don\'t open browser tab automatically on start')
     parser.add_argument("--verbose", dest='verbose', action='store_true',
                         default=False, help="verbose output")
+    parser.add_argument('--refresh', dest='refresh',
+                        help='grafana refresh interval; '
+                             'only valid when connecting to live cluster')
     args = parser.parse_args()
 
     os.makedirs(PROMTIMER_LOGS_DIR, exist_ok=True)
@@ -269,7 +272,7 @@ def main():
             sys.exit(1)
         min_time = 'now-30m'
         max_time = 'now'
-        refresh = '5s'
+        refresh = args.refresh or '5s'
 
     if not args.buckets:
         buckets = stats_sources[0].get_buckets()

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -118,7 +118,8 @@ def make_data_sources(stats_sources):
         password = ''
         if auth_required:
             user = stats_source.basic_auth_user()
-            password = stats_source.basic_auth_password()
+            # https://github.com/grafana/grafana/issues/17986
+            password = stats_source.basic_auth_password().replace("$", "$$")
         data_source_name = stats_source.short_name()
         replacement_map = {'data-source-name': data_source_name,
                            'data-source-host': stats_source.host(),

--- a/promtimer/util.py
+++ b/promtimer/util.py
@@ -65,13 +65,17 @@ def poll_processes(processes, count=-1):
 
 def execute_request(url, path, method='GET', data=None,
                     username=None, password=None, headers=None,
-                    retries=0):
+                    retries=0, secure=False):
     m = re.match('https?://', url, re.IGNORECASE)
     if m:
         scheme = m.group(0).lower()
     else:
-        url = 'http://{}'.format(url)
-        scheme = 'http://'
+        if secure:
+            url = 'https://{}'.format(url)
+            scheme = 'https://'
+        else:
+            url = 'http://{}'.format(url)
+            scheme = 'http://'
 
     handlers = []
     if username is not None:


### PR DESCRIPTION
This PR adds support for Promtimer to debug a live Capella cluster. A few fixes were needed to make this possible with the strict security requirements we have.

- Fix clusters using TLS - Capella only listens on TLS ports
- Fix passwords containting $ - Capella passwords contain special characters. Due to a bug in Grafana we need to escape passwords with $ in them
- Add ability to configure default refresh rate - Every dashboard refresh is going over the internet and costs customers money
- Add ability to receive node list - Support can only connect to clusters using port forwarding to localhost so we can't take the hostnames from the seed node