### PR TITLE
Use a hash of the data source name for the data source UID

### DIFF
--- a/data-source.yaml
+++ b/data-source.yaml
@@ -19,7 +19,7 @@ datasources:
     orgId: 1
     # <string> custom UID which can be used to reference this datasource in other parts of the configuration,
     # if not specified will be generated automatically
-    uid: "{data-source-name}"
+    uid: "{data-source-uid}"
     # <string> url
     url: "{data-source-scheme}://{data-source-host}:{data-source-port}/{data-source-path}"
     # <bool> enable/disable basic auth

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -26,6 +26,7 @@ import webbrowser
 import sys
 import getpass
 import logging
+import hashlib
 
 # local imports
 import util
@@ -121,7 +122,9 @@ def make_data_sources(stats_sources):
             # https://github.com/grafana/grafana/issues/17986
             password = stats_source.basic_auth_password().replace("$", "$$")
         data_source_name = stats_source.short_name()
+        uid = hashlib.sha1(data_source_name.encode("UTF-8")).hexdigest()
         replacement_map = {'data-source-name': data_source_name,
+                           'data-source-uid': uid,
                            'data-source-scheme': stats_source.scheme(),
                            'data-source-host': stats_source.host(),
                            'data-source-port': str(stats_source.port()),


### PR DESCRIPTION
The UID is constrained to have a max length of 40 characters. Previously we were just using the data source name for the UID, but this is obviously problematic in the general case. A simple solution that retains a deterministic value for the UID is to use a SHA1 hash for it, the hex representation of which has the additional convenient property that it is precisely 40 characters.