### PR TITLE
Use user provided URL when cluster node doesn't have hostname

### DIFF
--- a/promtimer/cbstats.py
+++ b/promtimer/cbstats.py
@@ -502,7 +502,10 @@ class ServerNode(Source):
             for node in node_services['nodesExt']:
                 host = node.get('hostname')
                 if host is None:
-                    host = '127.0.0.1'
+                    # There will be no hostname present if the target node in the cluster
+                    # is configured on loopback (i.e. 127.0.0.1). So, in this case use
+                    # the hostname that we used to access the server in the first place.
+                    host = url.hostname
                 services = node['services']
                 port = services['mgmtSSL'] if secure else services['mgmt']
                 source = ServerNode(host, port, user, password, util.is_https(url.scheme))
@@ -527,7 +530,8 @@ class ServerNode(Source):
                         break
                 real_host = this_node.get('hostname')
                 if not real_host:
-                    real_host = '127.0.0.1'
+                    # See comment in get_stats_sources
+                    real_host = url.hostname
                 services = this_node['services']
                 real_port = services['mgmtSSL'] if secure else services['mgmt']
                 short_name = f'{real_host}:{real_port}'


### PR DESCRIPTION
If we're connecting to a live cluster node that is configured against the loopback address (i.e. 127.0.0.1), it means the pools/defaul/nodeServices REST response will not contain a hostname for this node. To this point, we've been assuming that Promtimer is running on the same host as the target node - but generally it is better to use the host that the user provided us to access the node instead. This patch makes that change.