### PR TITLE
Increase number of connection attempts to connect to Grafana

### DIFF
--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -185,7 +185,7 @@ def connect_to_grafana(grafana_port):
     :return: the REST API response
     """
     url = 'http://localhost:{}'.format(grafana_port)
-    resp = util.execute_request(url, 'api/datasources', retries=3)
+    resp = util.execute_request(url, 'api/datasources', retries=50)
     logging.debug('connected to grafana at {}; response status: {}'.format(
                   grafana_port, resp.status))
     return resp

--- a/promtimer/util.py
+++ b/promtimer/util.py
@@ -222,7 +222,8 @@ def execute_request(url, path, method='GET', data=None,
     if not path.startswith('/'):
         path = '/' + path
     url = '{}{}'.format(url, path)
-    while retries >= 0:
+    attempts = 0
+    while True:
         try:
             if headers is None:
                 headers = {}
@@ -234,9 +235,11 @@ def execute_request(url, path, method='GET', data=None,
             return response
         except urllib.request.URLError as ue:
             logging.debug('Attempting connection to {}, '
-                          'retrying... {} retries left'.format(url, retries))
-            retries -= 1
+                          'retrying... {} retries left'.format(url, retries - attempts))
+            attempts += 1
             if retries < 0:
+                logging.warn('Failed to connect to {} after {} '
+                             'attempts: {}'.format(url, attempts, ue))
                 raise
             time.sleep(0.1)
     return None


### PR DESCRIPTION
I'm seeing the current 3 attempts intermittently fail on my machine; increasing to 50 (5s total).

Also improve error reporting when max number of retries exceeded.