### PR TITLE
Add chronicle sync latency distribution heatmap.

### DIFF
--- a/dashboards/chronicle-node.json
+++ b/dashboards/chronicle-node.json
@@ -41,7 +41,6 @@
         "label": "Node",
         "multi": false,
         "name": "node",
-        "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
@@ -88,6 +87,26 @@
         }
       ],
       "description": "Average chronicle fsync latency (i.e. total time waiting for fsyncs\ndivided by the number of fsyncs in the period. Computed as: `1000 * irate(cm_chronicle_disk_latency_seconds_sum{op=\"sync\"}[5m]) /\nignoring(name) irate(cm_chronicle_disk_latency_seconds_count{op=\"sync\"}[5m])`"
+    },
+    {
+      "title": "chronicle sync latency heatmap",
+      "legend": {"show": true},
+        "options": {
+          "calculate": false,
+          "yAxis": {"unit": "s"}
+        },
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "{data-source-name}",
+          "expr": "sum by (le)(increase(cm_chronicle_disk_latency_seconds_bucket{op=\"sync\"}[5m]))",
+          "legendFormat": "{{le}}",
+          "format": "heatmap",
+          "_base": "target"
+        }
+      ],
+      "type": "heatmap",
+      "description": "Plots increase in chronicle sync latency buckets (averaged over 5 minutes). We can see which buckets have hits and their hit rate (reflected by the color)."
     },
     {
       "title": "number of chronicle appends / s",


### PR DESCRIPTION
Add chronicle sync latency heatmap. In the event of 15 second leader [timeouts](https://issues.couchbase.com/browse/CBSE-14661?focusedId=694217&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-694217), there is usually a question about average chronicle latency not indicating something in the range of 15 seconds.

Visualize latency bucket distribution over time using heatmap (https://opstrace.com/blog/grafana-histogram-howto).