### PR TITLE
Add Magma write amp related stats

### DIFF
--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -225,6 +225,7 @@
     {
       "_base": "panel",
       "datasource": "${node}",
+      "title": "Thread pool CPU",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -237,97 +238,13 @@
       },
       "targets": [
         {
-          "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}[20s])",
+          "expr": "sum by (thread_pool) (rate(kv_thread_cpu_usage_seconds[6m]))",
+          "format": "time_series",
+          "instant": false,
           "interval": "",
-          "legendFormat": "total",
-          "range": true,
+          "legendFormat": "{{label_name}}",
           "refId": "A"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_write_bytes_compact_bytes{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "compactions",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Write bytes rate"
-    },
-    {
-      "_base": "panel",
-      "datasource": "${node}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 5
-          }
-        }
-      },
-      "gridPos": {
-        "h": 9
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_read_bytes_bytes{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "total",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_read_bytes_compact_bytes{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "compactions",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_read_bytes_get_bytes{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "gets",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_bytes_outgoing_bytes{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "outgoing",
-          "range": true,
-          "refId": "F"
-        }
-      ],
-     
-      "title": "Read bytes rate"
-    },
-    {
-      "_base": "panel",
-      "title": "Read IO rate",
-      "datasource": "${node}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 5
-          }
-        }
-      },
-      "gridPos": {
-        "h": 9
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_readio{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "readio",
-          "range": true,
-          "refId": "C"
         }
       ]
     },
@@ -347,42 +264,97 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_logical_data_size_bytes{bucket=\"$bucket\"}",
+          "expr": "rate(kv_ep_magma_compactions{bucket=\"$bucket\"}[20s])",
           "hide": false,
-          "legendFormat": "data",
+          "legendFormat": "compactions",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_logical_disk_size_bytes{bucket=\"$bucket\"}",
+          "expr": "rate(kv_magma_compactions{for=\"keyindex\",bucket=\"$bucket\"}[20s])",
           "hide": false,
-          "legendFormat": "disk",
+          "legendFormat": "key",
           "range": true,
           "refId": "B"
         },
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_history_logical_data_size{bucket=\"$bucket\"}",
+          "expr": "rate(kv_magma_compactions{for=\"seqindex\",bucket=\"$bucket\"}[20s])",
           "hide": false,
-          "legendFormat": "history data",
+          "legendFormat": "seq",
           "range": true,
           "refId": "C"
         },
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_history_logical_disk_size{bucket=\"$bucket\"}",
+          "expr": "rate(kv_ep_magma_ttl_compactions{bucket=\"$bucket\"}[20s])",
           "hide": false,
-          "legendFormat": "history disk",
+          "legendFormat": "ttl",
           "range": true,
           "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_filecount_compactions{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "filecount",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_keyindex_filecount_compactions{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "key filecount",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_filecount_compactions{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "seq filecount",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_writer_compactions{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "writer",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_keyindex_writer_compactions{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "key writer",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_writer_compactions{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "seq writer",
+          "range": true,
+          "refId": "J"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_data_compactions{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "seq data level",
+          "range": true,
+          "refId": "K"
         }
       ],
-      "title": "Logical size"
+      "title": "Compaction rate"
     },
     {
       "_base": "panel",
-      "datasource": "${node}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -390,36 +362,21 @@
           }
         }
       },
+      "datasource": "${node}",
       "gridPos": {
         "h": 9
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"}",
+          "expr": "rate(kv_ep_magma_flushes{bucket=\"$bucket\"}[20s])",
           "hide": false,
-          "legendFormat": "uncompressed",
+          "legendFormat": "flushes",
           "range": true,
           "refId": "A"
-        },
-        {
-          "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"}",
-          "hide": false,
-          "legendFormat": "compressed",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio{bucket=\"$bucket\"}*100",
-          "hide": false,
-          "legendFormat": "space reduction %",
-          "range": true,
-          "refId": "C"
         }
       ],
-      "title": "Data block compression"
+      "title": "Flush rate"
     },
     {
       "_base": "panel",
@@ -460,57 +417,6 @@
         }
       ],
       "title": "Tables"
-    },
-    {
-      "_base": "panel",
-      "datasource": "${node}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 5
-          }
-        }
-      },
-      "gridPos": {
-        "h": 9
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "kv_ep_magma_total_disk_usage_bytes{bucket=\"$bucket\"}",
-          "interval": "",
-          "legendFormat": "total",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "kv_ep_magma_wal_disk_usage{bucket=\"$bucket\"}",
-          "interval": "",
-          "legendFormat": "wal",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "editorMode": "code",
-          "expr": "kv_ep_magma_checkpoint_disk_usage{bucket=\"$bucket\"}",
-          "hide": false,
-          "legendFormat": "checkpoint",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "editorMode": "code",
-          "expr": "kv_ep_magma_active_disk_usage{bucket=\"$bucket\"}",
-          "hide": false,
-          "legendFormat": "active",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "Disk usage"
     },
     {
       "_base": "panel",
@@ -610,6 +516,644 @@
     },
     {
       "_base": "panel",
+      "title": "Disk IO",
+      "type": "row"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}[2m])",
+          "interval": "",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_write_bytes_compact_bytes{bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "compactions",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(kv_magma_write_bytes_{for=\"keyindex\", bucket=\"$bucket\"}[2m])",
+          "interval": "",
+          "legendFormat": "keyindex",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\", bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "seqindex",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "seqindex delta levels",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_write_bytes_filecount_compact_bytes{for=\"keyindex\",bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "keyindex filecount",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_write_bytes_filecount_compact_bytes{for=\"seqindex\",bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "seqindex filecount",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "seqindex data level",
+            "binary": {
+              "left": "seqindex",
+              "reducer": "sum",
+              "operator":"-",
+              "right": "seqindex delta levels"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "title": "Write bytes rate"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_write_bytes_compact_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "compactions",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_magma_write_bytes_{for=\"keyindex\", bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "keyindex",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_magma_write_bytes_bytes{for=\"seqindex\", bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "seqindex",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "seqindex delta levels",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_magma_write_bytes_filecount_compact_bytes{for=\"keyindex\",bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "keyindex filecount",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_magma_write_bytes_filecount_compact_bytes{for=\"seqindex\",bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "seqindex filecount",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "seqindex data level",
+            "binary": {
+              "left": "seqindex",
+              "reducer": "sum",
+              "operator":"-",
+              "right": "seqindex delta levels"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "title": "Write bytes"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[2m])",
+          "interval": "",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"keyindex\",bucket=\"$bucket\"}[2m])",
+          "interval": "",
+          "legendFormat": "keyindex",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\",bucket=\"$bucket\"}[2m])",
+          "interval": "",
+          "legendFormat": "seqindex",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{bucket=\"$bucket\"}[2m])",
+          "interval": "",
+          "legendFormat": "seqindex delta levels",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Bytes incoming rate",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "seqindex data level",
+            "binary": {
+              "left": "seqindex",
+              "reducer": "sum",
+              "operator":"-",
+              "right": "seqindex delta levels"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_magma_bytes_incoming_bytes{for=\"keyindex\",bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "keyindex",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_magma_bytes_incoming_bytes{for=\"seqindex\",bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "seqindex",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_ep_magma_seqindex_delta_bytes_incoming_bytes{bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "seqindex delta levels",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Bytes incoming",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "seqindex data level",
+            "binary": {
+              "left": "seqindex",
+              "reducer": "sum",
+              "operator":"-",
+              "right": "seqindex delta levels"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_read_bytes_bytes{bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_read_bytes_compact_bytes{bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "compactions",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_read_bytes_get_bytes{bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "gets",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+     
+      "title": "Read bytes rate"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_read_bytes_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_read_bytes_compact_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "compactions",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_read_bytes_get_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "gets",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+     
+      "title": "Read bytes"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_bytes_outgoing_bytes{bucket=\"$bucket\"}[2m])",
+          "hide": false,
+          "legendFormat": "outgoing",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Bytes outgoing rate"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_bytes_outgoing_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "outgoing",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Bytes outgoing"
+    },
+    {
+      "_base": "panel",
+      "title": "Read IO rate",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_readio{bucket=\"$bucket\"}[20s])",
+          "hide": false,
+          "legendFormat": "readio",
+          "range": true,
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "_base": "panel",
+      "title": "Size",
+      "type": "row"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_ep_magma_total_disk_usage_bytes{bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "kv_ep_magma_wal_disk_usage_bytes{bucket=\"$bucket\"}",
+          "interval": "",
+          "legendFormat": "wal",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_checkpoint_disk_usage_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "checkpoint",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_active_disk_usage_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "active",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Disk usage"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_logical_data_size_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "data",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_logical_disk_size_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "disk",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_history_logical_data_size_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "history data",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_history_logical_disk_size_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "history disk",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Logical size"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "uncompressed",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "compressed",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio{bucket=\"$bucket\"}*100",
+          "hide": false,
+          "legendFormat": "space reduction %",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Data block compression"
+    },
+    {
+      "_base": "panel",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -637,125 +1181,8 @@
     },
     {
       "_base": "panel",
-      "datasource": "${node}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 5
-          }
-        }
-      },
-      "gridPos": {
-        "h": 9
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "compactions",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_keyindex_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "key",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "seq",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_ttl_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "ttl",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_filecount_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "filecount",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_keyindex_filecount_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "key filecount",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_filecount_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "seq filecount",
-          "range": true,
-          "refId": "G"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_writer_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "writer",
-          "range": true,
-          "refId": "H"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_keyindex_writer_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "key writer",
-          "range": true,
-          "refId": "I"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_writer_compactions{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "seq writer",
-          "range": true,
-          "refId": "J"
-        }
-      ],
-      "title": "Compaction rate"
-    },
-    {
-      "_base": "panel",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "fillOpacity": 5
-          }
-        }
-      },
-      "datasource": "${node}",
-      "gridPos": {
-        "h": 9
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "rate(kv_ep_magma_flushes{bucket=\"$bucket\"}[20s])",
-          "hide": false,
-          "legendFormat": "flushes",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Flush rate"
+      "title": "History",
+      "type": "row"
     },
     {
       "_base": "panel",
@@ -773,7 +1200,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_history_size_evicted{bucket=\"$bucket\"}[20s])",
+          "expr": "rate(kv_ep_magma_history_size_evicted_bytes{bucket=\"$bucket\"}[20s])",
           "hide": false,
           "legendFormat": "size",
           "range": true,
@@ -781,14 +1208,14 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_history_time_evicted{bucket=\"$bucket\"}[20s])",
+          "expr": "rate(kv_ep_magma_history_time_evicted_bytes{bucket=\"$bucket\"}[20s])",
           "hide": false,
           "legendFormat": "time",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "History eviction rate"
+      "title": "History eviction bytes rate"
     },
     {
       "_base": "panel",
@@ -806,12 +1233,330 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "kv_ep_db_history_start_timestamp{bucket=\"$bucket\"}",
+          "expr": "kv_ep_db_history_start_timestamp_seconds{bucket=\"$bucket\"}",
           "legendFormat": "timestamp",
           "refId": "A"
         }
       ],
       "title": "History start timestamp"
+    },
+    {
+      "_base": "panel",
+      "title": "WriteAmp",
+      "type": "row"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "avg by (job)(rate(kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "hide": false,
+          "legendFormat": "overall",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "hide": false,
+          "legendFormat": "keyindex",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "hide": false,
+          "legendFormat": "seqindex",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "hide": false,
+          "legendFormat": "seqindex delta",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "(avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m]))-avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "hide": false,
+          "legendFormat": "seqindex data",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title":"Overall write amp breakdown"
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "write bytes",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"keyindex\", bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "bytes incoming",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title":"Key index write amp",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "write amp",
+            "binary": {
+              "left": "write bytes",
+              "reducer": "sum",
+              "operator":"/",
+              "right": "bytes incoming"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ]
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "write bytes",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\", bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "bytes incoming",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title":"Seq index write amp",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "write amp",
+            "binary": {
+              "left": "write bytes",
+              "reducer": "sum",
+              "operator":"/",
+              "right": "bytes incoming"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ]
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "delta write bytes",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "delta bytes incoming",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "write bytes",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "bytes incoming",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title":"Seq index data level write amp",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "data write bytes",
+            "binary": {
+              "left": "write bytes",
+              "reducer": "sum",
+              "operator":"-",
+              "right": "delta write bytes"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "data bytes incoming",
+            "binary": {
+              "left": "bytes incoming",
+              "reducer": "sum",
+              "operator":"-",
+              "right": "delta bytes incoming"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "write amp",
+            "binary": {
+              "left": "data write bytes",
+              "reducer": "sum",
+              "operator":"/",
+              "right": "data bytes incoming"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ]
+    },
+    {
+      "_base": "panel",
+      "datasource": "${node}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 5
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "write bytes",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[15m])",
+          "hide": false,
+          "legendFormat": "bytes incoming",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title":"Seq index delta levels write amp",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "write amp",
+            "binary": {
+              "left": "write bytes",
+              "reducer": "sum",
+              "operator":"/",
+              "right": "bytes incoming"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add stats to understand write bytes/bytes incoming rate for each of the Magma components - key index, seq index data, seq index delta.

Additionally some other stat names were fixed. They were missing the "_bytes" suffix and hence were not showing up.