### PR TITLE
Fix missing data when using $__rate_interval & high zoom

### DIFF
--- a/data-source.yaml
+++ b/data-source.yaml
@@ -30,7 +30,7 @@ datasources:
     # <bool> allow users to edit datasources from the UI.
     editable: true
     jsonData:
-      timeInterval: 1s
+      timeInterval: 10s
       tlsSkipVerify: true
     # <string> json object of data that will be encrypted.
     secureJsonData:


### PR DESCRIPTION
The tempalate for data sources sets the timeInterval - aka the scape interval for the prometheus instances - to 1s. However our actual Prometheus instances scape at an interval of at least 10s. I have observed that at a 30mins zoom level, Grafana derives an interval (as used by $__rate_interval) of less than our actual scape interval (10s+), which results in no data being seen in the panel.

This behaviour is explained in a Grafana blog post announcing $__rate_interval [1], which explains that if a data source has a scape interval incorrectly set (i.e. less than how often is it actually scraped), then __rate_interval's calculation willbe too short and rates cannot be calculated (Grafana doesn't observe sufficient samples in the requested interval).

Fix this by changing the default data source timeInterval to 10s - rate() graphs are now correctly shown at any zoom.

[1]: https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/