### PR TITLE
Replace usage of sys_cpu_utilization_rate

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -67,13 +67,13 @@ Let's also give the panel a better title:
       "_base": "dashboard",
       "_panels": [
         {
-          "title": "sys_cpu_utilization_rate",
+          "title": "sys_cpu_host_utilization_rate",
           "_base": "panel",
           "_targets": [
             {
               "datasource": "{data-source-name}",
-              "expr": "sys_cpu_utilization_rate",
-              "legendFormat": "{data-source-name} sys_cpu_utilization_rate",
+              "expr": "sys_cpu_host_utilization_rate",
+              "legendFormat": "{data-source-name} sys_cpu_host_utilization_rate",
               "_base": "target"
             }
           ]
@@ -82,7 +82,7 @@ Let's also give the panel a better title:
     }
 
 You will notice that the panel now contains one or more time series traces, or targets. Each target
-is the `sys_cpu_utilization_rate` for one of the cbcollects against which Promtimer is run. This
+is the `sys_cpu_host_utilization_rate` for one of the cbcollects against which Promtimer is run. This
 happens because the target contains at least one instance of the Promtimer template parameter
 `{data-source-name}` which is automatically expanded by Promtimer to add one trace per data source,
 or cbcollect.
@@ -96,14 +96,14 @@ Add a data-source-name parameter to the panel, as follows:
       "_base": "dashboard",
       "_panels": [
         {
-          "title": "sys_cpu_utilization_rate",
+          "title": "sys_cpu_host_utilization_rate",
           "datasource": "{data-source-name}",
           "_base": "panel",
           "_targets": [
             {
               "datasource": "{data-source-name}",
-              "expr": "sys_cpu_utilization_rate",
-              "legendFormat": "{data-source-name} sys_cpu_utilization_rate",
+              "expr": "sys_cpu_host_utilization_rate",
+              "legendFormat": "{data-source-name} sys_cpu_host_utilization_rate",
               "_base": "target"
             }
           ]

--- a/dashboards/cluster-overview.json
+++ b/dashboards/cluster-overview.json
@@ -35,13 +35,13 @@
   },
   "_panels": [
     {
-      "title": "sys_cpu_utilization_rate",
+      "title": "sys_cpu_host_utilization_rate",
       "_base": "panel",
       "_targets": [
         {
           "datasource": "{data-source-name}",
-          "expr": "sys_cpu_utilization_rate",
-          "legendFormat": "{data-source-name} sys_cpu_utilization_rate",
+          "expr": "sys_cpu_host_utilization_rate",
+          "legendFormat": "{data-source-name} sys_cpu_host_utilization_rate",
           "_base": "target"
         }
       ],

--- a/dashboards/node-overview.json
+++ b/dashboards/node-overview.json
@@ -52,12 +52,12 @@
   },
   "_panels": [
     {
-      "title": "sys_cpu_utilization_rate",
+      "title": "sys_cpu_host_utilization_rate",
       "datasource": "{data-source-name}",
       "_base": "panel",
       "_targets": [
         {
-          "expr": "sys_cpu_utilization_rate",
+          "expr": "sys_cpu_host_utilization_rate",
           "legendFormat": "",
           "_base": "target"
         }

--- a/dashboards/ns-server-dashboard.json
+++ b/dashboards/ns-server-dashboard.json
@@ -39,12 +39,12 @@
       "_base": "row"
     },
     {
-      "title": "sys_cpu_utilization_rate",
+      "title": "sys_cpu_host_utilization_rate",
       "_base": "panel",
       "_targets": [
         {
           "datasource": "{data-source-name}",
-          "expr": "sys_cpu_utilization_rate",
+          "expr": "sys_cpu_host_utilization_rate",
           "legendFormat": "{data-source-name} {{name}}",
           "_base": "target"
         }
@@ -70,8 +70,8 @@
       "_targets": [
         {
           "datasource": "{data-source-name}",
-          "expr": "sys_cpu_utilization_rate * ignoring(name)sys_cpu_cores_available",
-          "legendFormat": "{data-source-name} sys_cpu_utilization_rate (in cores)",
+          "expr": "sys_cpu_host_utilization_rate * ignoring(name)sys_cpu_cores_available",
+          "legendFormat": "{data-source-name} sys_cpu_host_utilization_rate (in cores)",
           "_base": "target"
         },
         {


### PR DESCRIPTION
Use sys_host_cpu_utilization_rate instead of sys_cpu_utilization_rate which is a cgroup stat. sys_cpu_utilization_rate has been replaced by a derived stat, sys_cpu_cgroup_usage_rate, which isn't available on all OSs.

Prior to this change sys_cpu_utilization_rate was defaulted to sys_host_cpu_utilization_rate anyways where cgroups were not supported.

The change in behavior will be when there are more than one cgroups and sys_host_cpu_utilization_rate doesn't reflect the rate for the cgroup containing Couchbase.

To get the cgroup stat via:

prometheus: sys_cpu_cgroup_usage_rate

curl: curl -u Administrator:asdasd localhost:8091/_prometheus/api/v1/query
 -d 'query=sys_cpu_cgroup_usage_rate' | jq