### PR TITLE
Add cgroup memory usage/limit

### DIFF
--- a/dashboards/node-overview.json
+++ b/dashboards/node-overview.json
@@ -212,6 +212,28 @@
           "unit": "s"
         }
       }
+    },
+    {
+      "title": "sys_mem_cgroup (limit/used)",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "sys_mem_cgroup_limit",
+          "legendFormat": "sys_mem_cgroup_limit",
+          "_base": "target"
+        },
+        {
+          "expr": "sys_mem_cgroup_used",
+          "legendFormat": "sys_mem_cgroup_used",
+          "_base": "target"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
A panel with the cgroup memory usage/limit is added to the node dashboard.