### PR TITLE
Changes to `KV View - Node & Bucket`

### DIFF
--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -278,6 +278,14 @@
         },
         {
           "exemplar": true,
+          "expr": "kv_ep_checkpoint_memory_bytes{bucket=\"$bucket\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "checkpoint_total",
+          "refId": "I"
+        },
+        {
+          "exemplar": true,
           "expr": "kv_vb_checkpoint_memory_queue_bytes{bucket=\"$bucket\"}",
           "hide": false,
           "interval": "",

--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -59,7 +59,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 10,
-        "w": 9
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 2,
@@ -212,7 +212,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 10,
-        "w": 9
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 18,
@@ -360,7 +360,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 10,
-        "w": 6
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 12,
@@ -453,8 +453,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 6
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 6,
@@ -553,8 +553,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 4
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 8,
@@ -618,10 +618,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 10,
-        "y": 10
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 24,
@@ -739,10 +737,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 14,
-        "y": 10
+        "h": 10,
+        "w": 8
       },
       "id": 26,
       "options": {
@@ -777,10 +773,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 19,
-        "y": 10
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 10,
@@ -855,8 +849,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 4
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 16,
@@ -939,8 +933,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 4
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 20,
@@ -999,8 +993,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 4
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 22,
@@ -1072,8 +1066,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 4
+        "h": 10,
+        "w": 8
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1176,7 +1170,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 8
       },
       "id": 28,
@@ -1274,7 +1268,7 @@
         }
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 8
       },
       "description": "Current counts of various items in the seqlist.",
@@ -1326,7 +1320,7 @@
         }
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 8
       },
       "description": "Total count of items deleted by the ItemPager due to memory usage being too high. These items might be kept in memory in the sequence list due to a range read (DCP)."

--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -39,6 +39,10 @@
   },
   "_panels": [
     {
+      "title": "General",
+      "_base": "row"
+    },
+    {
       "_base": "panel",
       "aliasColors": {},
       "bars": false,
@@ -1229,6 +1233,103 @@
       ],
       "title": "Ops",
       "type": "timeseries"
+    },
+    {
+      "title": "Ephemeral",
+      "_base": "row"
+    },
+    {
+      "title": "Ephemeral Sequence List",
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "${node}",
+          "expr": "kv_vb_seqlist_count",
+          "legendFormat": "total {{state}}",
+          "_base": "target"
+        },
+        {
+          "datasource": "${node}",
+          "expr": "kv_vb_seqlist_deleted_count",
+          "legendFormat": "deleted {{state}}",
+          "_base": "target"
+        },
+        {
+          "datasource": "${node}",
+          "expr": "kv_vb_seqlist_read_range_count",
+          "legendFormat": "range read {{state}}",
+          "_base": "target"
+        },
+        {
+          "datasource": "${node}",
+          "expr": "kv_vb_seqlist_stale_count",
+          "legendFormat": "stale {{state}}",
+          "_base": "target"
+        }
+      ],
+      "unit": "short",
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8
+      },
+      "description": "Current counts of various items in the seqlist.",
+      "overrides": [
+        {
+          "__systemRef": "hideSeriesFrom",
+          "matcher": {
+            "id": "byNames",
+            "options": {
+              "mode": "exclude",
+              "names": [
+                "total active",
+                "deleted active",
+                "range read active",
+                "stale active"
+              ],
+              "prefix": "All except:",
+              "readOnly": true
+            }
+          },
+          "properties": [
+            {
+              "id": "custom.hideFrom",
+              "value": {
+                "viz": true,
+                "legend": false,
+                "tooltip": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Ephemeral Automatic Deletion",
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "${node}",
+          "expr": "kv_vb_auto_delete_count",
+          "legendFormat": "auto_delete {{state}}",
+          "_base": "target"
+        }
+      ],
+      "unit": "short",
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8
+      },
+      "description": "Total count of items deleted by the ItemPager due to memory usage being too high. These items might be kept in memory in the sequence list due to a range read (DCP)."
     }
   ]
 }

--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -1110,6 +1110,10 @@
       "type": "graph"
     },
     {
+      "title": "Operations",
+      "_base": "row"
+    },
+    {
       "_base": "panel",
       "datasource": "${node}",
       "fieldConfig": {
@@ -1218,8 +1222,56 @@
           "refId": "E"
         }
       ],
-      "title": "Ops",
+      "title": "Total operations by vBucket state",
       "type": "timeseries"
+    },
+    {
+      "title": "Rate of MCBP operations",
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "${node}",
+          "expr": "rate(kv_cmd_duration_seconds_count{bucket=\"$bucket\", opcode!~\"DCP_.*\"}[5m]) > 0",
+          "legendFormat": "{{opcode}}",
+          "_base": "target"
+        }
+      ],
+      "unit": "short",
+      "noValue": "0",
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8
+      },
+      "description": "Number of MCBP commands executed per second, averaged over 5 minutes."
+    },
+    {
+      "title": "Rate of DCP operations",
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "${node}",
+          "expr": "rate(kv_cmd_duration_seconds_count{bucket=\"$bucket\", opcode=~\"DCP_.*\"}[5m]) > 0",
+          "legendFormat": "{{opcode}}",
+          "_base": "target"
+        }
+      ],
+      "unit": "short",
+      "noValue": "0",
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8
+      },
+      "description": "Number of DCP commands executed per second, averaged over 5 minutes."
     },
     {
       "title": "Ephemeral",

--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -243,13 +243,6 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kv_ep_max_size{bucket=\"$bucket\"}",
-          "interval": "",
-          "legendFormat": "Bucket Quota",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
           "expr": "kv_ep_checkpoint_memory_quota_bytes{bucket=\"$bucket\"}",
           "hide": false,
           "interval": "",

--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -141,7 +141,7 @@
         },
         {
           "exemplar": true,
-          "expr": "kv_memory_used_bytes{bucket=\"$bucket\"}",
+          "expr": "kv_memory_used_bytes{bucket=\"$bucket\", for=~\"blobs|storedvalues\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Mem used - {{for}}",

--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -176,7 +176,7 @@
           "expr": "kv_dcp_ready_queue_size_bytes{bucket=\"$bucket\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "DCP readyQ",
+          "legendFormat": "DCP readyQ ({{connection_type}})",
           "refId": "L"
         }
       ],


### PR DESCRIPTION
- Added some useful metrics, removed some which are generally not useful. 
- Grouped some things in rows and resized all of the panels to be the same size. 
- Before, we had rows in the grid of 2, 3, 4 and 5 panels on each row, which made visually correlating events more difficult.

---

## Before
![before](https://github.com/couchbaselabs/promtimer/assets/12015256/16d5548b-f555-467e-bc88-4ed726033652)

---
## After
![after](https://github.com/couchbaselabs/promtimer/assets/12015256/ec023a77-f5df-4852-a140-a99873edf2ff)
