### PR TITLE
[KV] Add Pageable memory counters relevant to Ephemeral

### DIFF
--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -203,6 +203,86 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${node}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(kv_ep_mem_low_wat{bucket=\"$bucket\"} / on(bucket) kv_ep_vb_total{bucket=\"$bucket\"}) * on(bucket) (kv_num_vbuckets{state=\"active\",bucket=\"$bucket\"} + on(bucket) kv_num_vbuckets{state=\"pending\", bucket=\"$bucket\"})",
+          "interval": "",
+          "legendFormat": "Pageable LWM",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "(kv_ep_mem_high_wat{bucket=\"$bucket\"} / on(bucket) kv_ep_vb_total{bucket=\"$bucket\"}) * on(bucket) (kv_num_vbuckets{state=\"active\",bucket=\"$bucket\"} + on(bucket) kv_num_vbuckets{state=\"pending\",bucket=\"$bucket\"})",
+          "interval": "",
+          "legendFormat": "Pageable HWM",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "kv_mem_used_bytes{bucket=\"$bucket\"} - on(bucket) (kv_memory_used_bytes{bucket=\"$bucket\", for=\"hashtable\"} * on(bucket) (kv_num_vbuckets{bucket=\"$bucket\", state=\"replica\"} / on(bucket) kv_ep_vb_total{bucket=\"$bucket\"})) - on(bucket) (kv_vb_checkpoint_memory_overhead_bytes{state=\"replica\", bucket=\"$bucket\"})" ,
+          "interval": "",
+          "legendFormat": "Pageable Mem Used",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Ephemeral Adjusted Memory counters",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph"
+    },
+    {
+      "_base": "panel",
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${node}",
       "fieldConfig": {
         "defaults": {
           "unit": "bytes"


### PR DESCRIPTION
HWM/LWM and mem_used are less interesting in their raw state for ephemeral. The adjusted counters are needed when looking at paging triggers.