### PR TITLE
[KV] Fix "Num resident" in KV Node & Bucket

### DIFF
--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -408,100 +408,48 @@
     },
     {
       "_base": "panel",
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "${node}",
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8
       },
-      "hiddenSeries": false,
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.1.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
-          "exemplar": true,
           "expr": "kv_curr_items{bucket=\"$bucket\"}",
-          "interval": "",
-          "legendFormat": "Items (active)",
-          "refId": "A"
+          "legendFormat": "Items (active)"
         },
         {
-          "exemplar": true,
           "expr": "kv_curr_items_tot{bucket=\"$bucket\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Items (active+replica)",
-          "refId": "B"
+          "legendFormat": "Items (active+replica)"
         },
         {
-          "exemplar": true,
           "expr": "kv_ep_num_non_resident{bucket=\"$bucket\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Num non-resident",
-          "refId": "C"
+          "legendFormat": "Num non-resident"
         },
         {
-          "exemplar": true,
-          "expr": "kv_ep_storedval_num{bucket=\"$bucket\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Num resident",
-          "refId": "D"
+          "expr": "kv_curr_items_tot{bucket=\"$bucket\"} - ignoring(name) kv_ep_num_non_resident{bucket=\"$bucket\"}",
+          "legendFormat": "Num resident"
         },
         {
-          "exemplar": true,
           "expr": "kv_ep_blob_num{bucket=\"$bucket\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Num blobs",
-          "refId": "E"
+          "legendFormat": "Num blobs"
         },
         {
-          "exemplar": true,
+          "expr": "kv_ep_storedval_num{bucket=\"$bucket\"}",
+          "legendFormat": "Num storedvals"
+        },
+        {
+          "expr": "kv_ep_item_num{bucket=\"$bucket\"}",
+          "legendFormat": "Num queued_items"
+        },
+        {
           "expr": "kv_ep_diskqueue_items{bucket=\"$bucket\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Disk queue size",
-          "refId": "F"
+          "legendFormat": "Disk queue size"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Num items",
+      "description": "* items - documents in vBuckets by state\n* blobs - item values (in HT or in DCP queues)\n* storedvals - item metadata in the HT\n* queued_items - `Item` objects in DCP queues or passed between memcached/ep-engine\n* disk queue - items waiting for persistence",
       "tooltip": {
-        "shared": true,
-        "sort": 0,
         "value_type": "individual"
       },
       "type": "graph"


### PR DESCRIPTION
The label is wrong. This is the number of metadata objects, not the number of resident items.

I've added the actual number of resident items, the number of "Item" objects (not the type we use in HT), and a panel description.

![image](https://github.com/couchbaselabs/promtimer/assets/12015256/3c9abbb1-fa00-4127-b078-4ea8fe70a377)
