### PR TITLE
Make dashboards use the same timezone as the logs by default

### DIFF
--- a/promtimer/dashboard.py
+++ b/promtimer/dashboard.py
@@ -181,10 +181,12 @@ def make_dashboard(dashboard_meta,
                    template_params,
                    min_time_string,
                    max_time_string,
-                   refresh):
+                   refresh,
+                   timezone):
     replacements = {'dashboard-from-time': min_time_string,
                     'dashboard-to-time': max_time_string,
-                    'dashboard-refresh': refresh}
+                    'dashboard-refresh': refresh,
+                    'dashboard-timezone': timezone}
     template_string = get_template(dashboard_meta['_base'])
     template_string = metaify_template_string(template_string, dashboard_meta)
     dashboard_string = templating.replace(template_string, replacements)

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -107,6 +107,7 @@ def make_dashboards(stats_sources,
                     min_time_string,
                     max_time_string,
                     refresh_string,
+                    timezone_string,
                     dashboard_name_predicate):
     os.makedirs(get_dashboards_dir(), exist_ok=True)
     data_sources = [s.short_name() for s in stats_sources]
@@ -124,7 +125,8 @@ def make_dashboards(stats_sources,
                                             template_params,
                                             min_time_string,
                                             max_time_string,
-                                            refresh_string)
+                                            refresh_string,
+                                            timezone_string)
             dash['uid'] = base_file_name[:-len('.json')]
             with open(path.join(get_dashboards_dir(), base_file_name), 'w') as file:
                 file.write(json.dumps(dash, indent=2))
@@ -162,6 +164,7 @@ def make_data_sources(stats_sources):
 
 
 def prepare_grafana(grafana_port,
+                    grafana_timezone,
                     stats_sources,
                     buckets,
                     min_time_string,
@@ -180,7 +183,7 @@ def prepare_grafana(grafana_port,
     make_dashboards(
         stats_sources, buckets,
         min_time_string, max_time_string, refresh,
-        dashboard_name_predicate
+        grafana_timezone, dashboard_name_predicate
     )
 
 
@@ -329,6 +332,7 @@ def main():
     grafana_port = args.grafana_port
     prometheus_base_port = grafana_port + 1
     live_cluster = args.cluster or args.nodes
+    default_timezone = 'browser'
 
     if live_cluster and args.backup_archive_path:
         print("--cluster and --backup-archive-path are mutually exclusive options")
@@ -375,6 +379,15 @@ def main():
         times = cbstats.CBCollect.compute_min_and_max_times(stats_sources)
         min_time = datetime.datetime.fromtimestamp(times[0]).isoformat()
         max_time = datetime.datetime.fromtimestamp(times[1]).isoformat()
+
+        timezone_override = os.environ.get('GRAFANA_TZ', '')
+        if timezone_override != '':
+            default_timezone = timezone_override
+        else:
+            default_timezone = cbstats.CBCollect.get_one_timezone(stats_sources)
+        logging.info('setting default timezone to {}'.format(
+            default_timezone))
+
         refresh = ''
 
     if not args.buckets and not args.backup_archive_path:
@@ -389,6 +402,7 @@ def main():
         dashboard_name_predicate = lambda x: x.startswith(BACKUPMGR_STATS)
 
     prepare_grafana(grafana_port,
+                    default_timezone,
                     stats_sources,
                     buckets,
                     min_time,

--- a/templates/dashboard.json
+++ b/templates/dashboard.json
@@ -49,7 +49,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "{dashboard-timezone}",
   "title": "Dashboard",
   "version": 0
 }


### PR DESCRIPTION
The dashboards are set to use the browsers timezone by default. This is perfect for attaching to a live test cluster running locally. For cbcollects however, we almost always need to remember to change the timezone.

My personal preference is to always use the timezone that is in the logs. I've added some extra parsing code which determines the timezone on the cbcollect host using:
 - /etc/timezone output from couchbase.log
 - cbcollect_info.log timestamps as fallback

In the fallback case, we can only observe an offset from UTC, not a timezone, which is not enough to determine the timezone that is applied on the cbcollect host. However, for round hour offsets from UTC, we can apply an 'Etc' timezone which gives us the same offset with no DST. In which case an offset of +01:00 maps to Etc/GMT-1.

There are no Etc IANA timezones for non-round offsets, so in that case, we will fallback to UTC.

The environment variable GRAFANA_TZ can be used to override this an set a desired value.