### PR TITLE
[KV] Fix rate interval of high-cardinality metrics

### DIFF
--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -611,7 +611,7 @@
       "_targets": [
         {
           "datasource": "${node}",
-          "expr": "rate(kv_cmd_duration_seconds_count{bucket=\"$bucket\", opcode!~\"DCP_.*\"}[5m]) > 0",
+          "expr": "rate(kv_cmd_duration_seconds_count{bucket=\"$bucket\", opcode!~\"DCP_.*\"}[10m]) > 0",
           "legendFormat": "{{opcode}}",
           "_base": "target"
         }
@@ -637,7 +637,7 @@
       "_targets": [
         {
           "datasource": "${node}",
-          "expr": "rate(kv_cmd_duration_seconds_count{bucket=\"$bucket\", opcode=~\"DCP_.*\"}[5m]) > 0",
+          "expr": "rate(kv_cmd_duration_seconds_count{bucket=\"$bucket\", opcode=~\"DCP_.*\"}[10m]) > 0",
           "legendFormat": "{{opcode}}",
           "_base": "target"
         }


### PR DESCRIPTION
ns_server varies the interval between 10s and 180s. To capture 3 data points for every output of rate(), use 10 minute interval (we do the same on the KV Node dashboard).