### PR TITLE
Add disk IO stats to node-overview dashboard

### DIFF
--- a/dashboards/node-overview.json
+++ b/dashboards/node-overview.json
@@ -234,6 +234,140 @@
           "unit": "bytes"
         }
       }
+    },
+    {
+      "title": "sys_disk_read_bytes (per second)",
+      "description": "The number of bytes read from disk per second.",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(sys_disk_read_bytes[$__rate_interval])",
+          "legendFormat": "{{disk}}",
+          "_base": "target"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        }
+      }
+    },
+    {
+      "title": "sys_disk_write_bytes (per second)",
+      "description": "The number of bytes written to disk per second.",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(sys_disk_write_bytes[$__rate_interval])",
+          "legendFormat": "{{disk}}",
+          "_base": "target"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        }
+      }
+    },
+    {
+      "title": "sys_disk_reads (per second)",
+      "description": "Disk read operations per second.",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(sys_disk_reads[$__rate_interval])",
+          "legendFormat": "{{disk}}",
+          "_base": "target"
+        }
+      ]
+    },
+    {
+      "title": "sys_disk_writes (per second)",
+      "description": "Disk write operations per second.",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(sys_disk_writes[$__rate_interval])",
+          "legendFormat": "{{disk}}",
+          "_base": "target"
+        }
+      ]
+    },
+    {
+      "title": "sys_disk_read_time",
+      "description": "Amount of time disk spent reading.",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(sys_disk_read_time_seconds[$__rate_interval])",
+          "legendFormat": "{{disk}}",
+          "_base": "target"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "title": "sys_disk_write_time",
+      "description": "Amount of time disk spent writing.",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(sys_disk_write_time_seconds[$__rate_interval])",
+          "legendFormat": "{{disk}}",
+          "_base": "target"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "title": "sys_disk_queue",
+      "description": "Current disk queue length.",
+      "datasource": "{data-source-name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "sys_disk_queue",
+          "legendFormat": "{{disk}}",
+          "_base": "target"
+        },
+        {
+          "expr": "sys_disk_queue_depth",
+          "legendFormat": "{{disk}} depth",
+          "_base": "target"
+        }
+      ],
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/depth/"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Graphs for the following stats are added to the Node-Overview panel:

- `sys_disk_read_bytes`
- `sys_disk_write_bytes`
- `sys_disk_reads`
- `sys_disk_writes`
- `sys_disk_read_time_seconds`
- `sys_disk_write_time_seconds`
- `sys_disk_queue` and `sys_disk_queue_depth`

The above disk stats are retrieved from `iostat`. They were added to Couchbase version 7.6 and backported to 7.2.4. These are useful to more easily debug cases where the disk may be the bottleneck, such as hitting an IOPS limit.

![image](https://github.com/user-attachments/assets/212a6799-8b30-4489-8d1b-4a20adab8554)
![image](https://github.com/user-attachments/assets/b64fa62b-bcdf-4ed0-97b3-f27aca0462b7)
![image](https://github.com/user-attachments/assets/3e0849a6-685b-4c5a-8367-6285f167cf11)
![image](https://github.com/user-attachments/assets/5de545e7-b17a-478d-a212-12fc2805aa5f)

