### PR TITLE
Add couch_docs_actual to magma dashboard

### DIFF
--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -1067,7 +1067,15 @@
           "legendFormat": "active",
           "range": true,
           "refId": "D"
-        }
+        },
+	{
+	  "editorMode": "code",
+          "expr": "couch_docs_actual_disk_size{bucket=\"$bucket\"}",
+          "hide": false,
+          "legendFormat": "couch_docs_actual",
+          "range": true,
+          "refId": "E"
+	}
       ],
       "title": "Disk usage"
     },


### PR DESCRIPTION
Before 7.6 release, couch_docs_actual_disk_size came from ns-server's godu. After 7.6 release, it comes from magma's total_disk_usage.

Useful to have both stats plotted, so that we're aware what release it is coming from, since before 7.6 magma's total_disk_usage was highly inaccurate.