### PR TITLE
MB-65284: Add fts_total_synonym_searches to Grafana dashboard

### DIFF
--- a/dashboards/search-dashboard.json
+++ b/dashboards/search-dashboard.json
@@ -287,6 +287,18 @@
             ]
           },
           {
+            "title": "fts_total_synonym_searches",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source-name}",
+                "expr": "fts_total_synonym_searches",
+                "legendFormat": "{data-source-name} fts_total_synonym_searches",
+                "_base": "target"
+              }
+            ]
+          },
+          {
             "title": "fts_total_bytes_indexed",
             "_base": "panel",
             "_targets": [


### PR DESCRIPTION
- Updated the Grafana tool to display fts_total_synonym_searches.
- Integrated Prometheus-exposed total_synonym_searches metric into the Grafana dashboard.
- Enables monitoring of total synonym searches performed in the FTS index.