### PR TITLE
[KV] Make Ephemeral Adjusted Memory panel more accurate

### DIFF
--- a/dashboards/kv-nodebucket.json
+++ b/dashboards/kv-nodebucket.json
@@ -704,15 +704,15 @@
       },
       "targets": [
         {
-          "expr": "(kv_ep_mem_low_wat{bucket=\"$bucket\"} / on(bucket) kv_ep_vb_total{bucket=\"$bucket\"}) * on(bucket) (kv_num_vbuckets{state=\"active\",bucket=\"$bucket\"} + on(bucket) kv_num_vbuckets{state=\"pending\", bucket=\"$bucket\"})",
+          "expr": "kv_ep_mem_low_wat{bucket=\"$bucket\"} / ignoring (name) kv_ep_vb_total{bucket=\"$bucket\"} * ignoring (name) sum without (state) (kv_num_vbuckets{bucket=\"$bucket\",state~=\"active|pending\"})",
           "legendFormat": "Pageable LWM"
         },
         {
-          "expr": "(kv_ep_mem_high_wat{bucket=\"$bucket\"} / on(bucket) kv_ep_vb_total{bucket=\"$bucket\"}) * on(bucket) (kv_num_vbuckets{state=\"active\",bucket=\"$bucket\"} + on(bucket) kv_num_vbuckets{state=\"pending\",bucket=\"$bucket\"})",
+          "expr": "kv_ep_mem_high_wat{bucket=\"$bucket\"} / ignoring (name) kv_ep_vb_total{bucket=\"$bucket\"} * ignoring (name) sum without (state) (kv_num_vbuckets{bucket=\"$bucket\",state~=\"active|pending\"})",
           "legendFormat": "Pageable HWM"
         },
         {
-          "expr": "kv_mem_used_bytes{bucket=\"$bucket\"} - on(bucket) (kv_ep_ht_item_memory_bytes{bucket=\"$bucket\"} * on(bucket) (kv_num_vbuckets{bucket=\"$bucket\", state=\"replica\"} / on(bucket) kv_ep_vb_total{bucket=\"$bucket\"})) - on(bucket) (kv_vb_checkpoint_memory_overhead_bytes{state=\"replica\", bucket=\"$bucket\"})",
+          "expr": "kv_mem_used_bytes{bucket=\"$bucket\"} - ignoring (name) sum without (state) (kv_vb_ht_item_memory_bytes{bucket=\"$bucket\", state~=\"replica|dead\"}) - ignoring (name) sum without (state) (kv_vb_checkpoint_memory_overhead_bytes{bucket=\"$bucket\",state~=\"replica|dead\"})",
           "legendFormat": "Pageable Mem Used"
         }
       ],


### PR DESCRIPTION
These are metrics we don't expose, but are critical to Ephemeral auto-delete.

The underlying calculation used is:

const auto estimatedActiveMemory =
        int64_t(stats.getEstimatedTotalMemoryUsed()) -
        stats.inactiveHTMemory - stats.inactiveCheckpointOverhead;

Where inactive means replica + dead vBuckets.

The previous calculation for Pageable Mem Current used an approximation for the inactiveHTMemory based on: totalHTMemory * inactive VB ratio.

But we have the inactiveHTMemory in stats, as the sum of the per-vBucket state metrics.

By using that, we get an accurate calculation.

I've also updated the LWM and HWM to use sum without (state) instead of addition for the two states.