### PR TITLE
Provide `data-source-uid` to dashboards & use in cbbackupmgr

### DIFF
--- a/dashboards/cbbackupmgr-stats.json
+++ b/dashboards/cbbackupmgr-stats.json
@@ -30,7 +30,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "expr": "global_usage{type=\"cpu\"}",
             "legendFormat": "__auto"
           }
@@ -45,7 +48,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "expr": "process_usage{type=\"cpu\"}",
             "legendFormat": "__auto",
             "refId": "A"
@@ -65,7 +71,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "expr": "io_time{type=\"disk\"}",
             "legendFormat": "__auto"
           }
@@ -80,7 +89,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "read_bytes",
             "legendFormat": "__auto"
@@ -96,7 +108,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "expr": "write_bytes{type=\"disk\"}",
             "legendFormat": "__auto"
           }
@@ -111,7 +126,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "read_count{type=\"disk\"}",
             "legendFormat": "__auto"
@@ -127,7 +145,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "expr": "write_count{type=\"disk\"}",
             "legendFormat": "__auto"
           }
@@ -142,7 +163,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "read_time{type=\"disk\"}",
             "legendFormat": "__auto"
@@ -158,7 +182,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "write_time{type=\"disk\"}",
             "legendFormat": "__auto"
@@ -174,7 +201,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "read_time{type=\"disk\"}",
             "legendFormat": "__auto"
@@ -194,7 +224,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "total{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -210,7 +243,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "available{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -226,7 +262,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "active{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -242,7 +281,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "inactive{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -258,7 +300,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "free{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -274,7 +319,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "used{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -290,7 +338,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "used_percent{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -306,7 +357,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "wired{type=\"memory\", stat=\"vm\"}",
             "legendFormat": "__auto"
@@ -322,7 +376,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "rss{type=\"memory\", stat=\"process\"}",
             "legendFormat": "__auto"
@@ -338,7 +395,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "vms{type=\"memory\", stat=\"process\"}",
             "legendFormat": "__auto"
@@ -358,7 +418,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "packets_sent{type=\"net\", stat=\"global_net_stats\"}",
             "legendFormat": "__auto"
@@ -374,7 +437,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "packets_received{type=\"net\", stat=\"global_net_stats\"}",
             "legendFormat": "__auto"
@@ -390,7 +456,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "bytes_sent{type=\"net\", stat=\"global_net_stats\"}",
             "legendFormat": "__auto"
@@ -406,7 +475,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "bytes_received{type=\"net\", stat=\"global_net_stats\"}",
             "legendFormat": "__auto"
@@ -422,7 +494,10 @@
         "_targets": [
           {
             "_base": "target",
-            "datasource": "{data-source-name}",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source-uid}"
+            },
             "editorMode": "builder",
             "expr": "dropout{type=\"net\", stat=\"global_net_stats\"}",
             "legendFormat": "__auto"

--- a/promtimer/dashboard.py
+++ b/promtimer/dashboard.py
@@ -145,6 +145,9 @@ def maybe_substitute_templating_variables(dashboard, template_params):
                 if template_param['type'] == 'data-source-name' and \
                                 templating['type'] == 'datasource':
                     template_param['values'] = ['$' + variable]
+                if template_param['type'] == 'data-source-uid' and \
+                                templating['type'] == 'datasource':
+                    template_param['values'] = ['$' + variable]
                 if template_param['type'] == 'bucket' and \
                                 templating['type'] == 'custom':
                     template_param['values'] = ['$' + variable]

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -110,9 +110,11 @@ def make_dashboards(stats_sources,
                     timezone_string,
                     dashboard_name_predicate):
     os.makedirs(get_dashboards_dir(), exist_ok=True)
-    data_sources = [s.short_name() for s in stats_sources]
+    data_source_names = [s.short_name() for s in stats_sources]
+    data_source_uids = [s.uid() for s in stats_sources]
     template_params = \
-        [{'type': 'data-source-name', 'values': data_sources},
+        [{'type': 'data-source-name', 'values': data_source_names},
+         {'type': 'data-source-uid', 'values': data_source_uids},
          {'type': 'bucket', 'values': buckets if buckets else []}]
     meta_file_names = glob.glob(path.join(util.get_root_dir(), 'dashboards', '*.json'))
     for meta_file_name in meta_file_names:
@@ -145,9 +147,8 @@ def make_data_sources(stats_sources):
             # https://github.com/grafana/grafana/issues/17986
             password = stats_source.basic_auth_password().replace("$", "$$")
         data_source_name = stats_source.short_name()
-        uid = hashlib.sha1(data_source_name.encode("UTF-8")).hexdigest()
         replacement_map = {'data-source-name': data_source_name,
-                           'data-source-uid': uid,
+                           'data-source-uid': stats_source.uid(),
                            'data-source-scheme': stats_source.scheme(),
                            'data-source-host': stats_source.host(),
                            'data-source-port': str(stats_source.port()),


### PR DESCRIPTION
After upgrading to Grafana 12 the cbbackupmgr dashboard stopped working, showing "no data". I found that it could be fixed by editing a visualisation, changing the datasource to something other than "cbmstatparser-prometheus-tsdb" and then back again.

After some digging it appears that the UI component is getting malformed data. For the normal cluster dashboards, all of which work, the UI component gets the source as `{type: "prometheus", uid: "123.."}`. On the cbbackupmgr ones it gets `"cbmstatparser-prometheus-tsdb"`.

There's no real difference between the dashboards for clusters and the one for cbbackupmgr that would explain this - both specify the name of the source, it just seems Grafana is converting one of them to the object and the other not. Unfortunately my React/TS skills aren't up to scratch to find where this happens.

To solve this I found that specifying the object in the dashboard itself fixes it. This commit passes the datasource uid to the dashboard templates and updates the cbbackupmgr dashboard to use it.