### PR TITLE
Refactor promtimer main function

### DIFF
--- a/promtimer/backupstats.py
+++ b/promtimer/backupstats.py
@@ -29,7 +29,7 @@ import cbstats
 def handle_backup_archive_mode(backup_archive_path: str,
                                cbmstatparser_bin: str,
                                prometheus_base_port: int) \
-        -> tuple[list[cbstats.BackupStatsFiles], str, str, str]:
+        -> tuple[list[cbstats.BackupStatsFiles], str, str]:
     """
     Handle setting up the backup archive so we're ready to run a Prometheus
     instance against it.
@@ -37,8 +37,7 @@ def handle_backup_archive_mode(backup_archive_path: str,
     :param cbmstatparser_bin: path to the cbmstatparser binary
     :param prometheus_base_port: base prometheus port to use
     :return: the list of stats sources, min and max timestamps associated
-             with the Prometheus metrics and whether any dashboard built
-             off this stats source should be refreshed
+             with the Prometheus metrics
     """
     archive_path = backup_archive_path
     if zipfile.is_zipfile(backup_archive_path):
@@ -80,4 +79,4 @@ def handle_backup_archive_mode(backup_archive_path: str,
     )
     min_time, max_time = min_time.isoformat(), max_time.isoformat()
 
-    return stats_sources, min_time, max_time, ""
+    return stats_sources, min_time, max_time


### PR DESCRIPTION
The entry point to the promtimer script was never great but had degraded over the years to become an almost incomprehensible collection of argument parsing, validation and running of the script. It was high time to clean it up some.

Changes:
* new entry-point function parse_args_validate_and_run that parses and does basic validation and invokes a new function: run_promtimer
* run_promtimer does essentially 3 things: 1) call make_stats_sources 2) call prepare_grafana 3) call start_processes_and monitor

This required some small other refactorings. In particular: 
a) get_timezone was elevated to be a method in StatsSource and
   the static method get_one_timezone now works with StatsSources
   rather than CBCollects which makes the code a bit simpler
b) handle_backup_archive_mode has been changed to not also return
   a refresh interval (as all it was doing was returning an empty string
   literal) and this is dealt with separately

This code can certainly be further simplified. However, this is a reasonable first step and good enough for now I think.

Tested all forms of running promtimer before submitting, that is, running against cbcollects, live clusters and backup archives.