### PR TITLE
Remove use of the data-source-uid parameter in dashboards

### DIFF
--- a/dashboards/cbbackupmgr-stats.json
+++ b/dashboards/cbbackupmgr-stats.json
@@ -32,7 +32,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "expr": "global_usage{type=\"cpu\"}",
             "legendFormat": "__auto"
@@ -50,7 +50,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "expr": "process_usage{type=\"cpu\"}",
             "legendFormat": "__auto",
@@ -73,7 +73,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "expr": "io_time{type=\"disk\"}",
             "legendFormat": "__auto"
@@ -91,7 +91,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "read_bytes",
@@ -110,7 +110,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "expr": "write_bytes{type=\"disk\"}",
             "legendFormat": "__auto"
@@ -128,7 +128,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "read_count{type=\"disk\"}",
@@ -147,7 +147,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "expr": "write_count{type=\"disk\"}",
             "legendFormat": "__auto"
@@ -165,7 +165,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "read_time{type=\"disk\"}",
@@ -184,7 +184,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "write_time{type=\"disk\"}",
@@ -203,7 +203,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "read_time{type=\"disk\"}",
@@ -226,7 +226,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "total{type=\"memory\", stat=\"vm\"}",
@@ -245,7 +245,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "available{type=\"memory\", stat=\"vm\"}",
@@ -264,7 +264,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "active{type=\"memory\", stat=\"vm\"}",
@@ -283,7 +283,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "inactive{type=\"memory\", stat=\"vm\"}",
@@ -302,7 +302,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "free{type=\"memory\", stat=\"vm\"}",
@@ -321,7 +321,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "used{type=\"memory\", stat=\"vm\"}",
@@ -340,7 +340,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "used_percent{type=\"memory\", stat=\"vm\"}",
@@ -359,7 +359,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "wired{type=\"memory\", stat=\"vm\"}",
@@ -378,7 +378,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "rss{type=\"memory\", stat=\"process\"}",
@@ -397,7 +397,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "vms{type=\"memory\", stat=\"process\"}",
@@ -420,7 +420,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "packets_sent{type=\"net\", stat=\"global_net_stats\"}",
@@ -439,7 +439,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "packets_received{type=\"net\", stat=\"global_net_stats\"}",
@@ -458,7 +458,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "bytes_sent{type=\"net\", stat=\"global_net_stats\"}",
@@ -477,7 +477,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "bytes_received{type=\"net\", stat=\"global_net_stats\"}",
@@ -496,7 +496,7 @@
             "_base": "target",
             "datasource": {
               "type": "prometheus",
-              "uid": "{data-source-uid}"
+              "uid": "{data-source:uid}"
             },
             "editorMode": "builder",
             "expr": "dropout{type=\"net\", stat=\"global_net_stats\"}",

--- a/promtimer/dashboard.py
+++ b/promtimer/dashboard.py
@@ -140,8 +140,7 @@ def maybe_substitute_templating_variables(
                 pname = param.name()
                 if (item['type'] == 'datasource') and \
                         (pname == 'data-source' or
-                         pname == 'data-source-name' or
-                         pname == 'data-source-uid') or \
+                         pname == 'data-source-name') or \
                         (pname == 'bucket' and item['type'] == 'custom'):
                     value = param.make_single_valued_value(f'${variable}')
                     template_params[idx] = (param, [value])

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -117,7 +117,6 @@ def make_dashboards(stats_sources,
         [(templating.Parameter('data-source', ['name', 'uid']),
             [{'name': s.short_name(), 'uid': s.uid()} for s in stats_sources]),
          (templating.Parameter('data-source-name'), data_source_names),
-         (templating.Parameter('data-source-uid'), data_source_uids),
          (templating.Parameter('bucket'), buckets if buckets else [])]
     meta_file_names = glob.glob(path.join(util.get_root_dir(), 'dashboards', '*.json'))
     for meta_file_name in meta_file_names:


### PR DESCRIPTION
It's now replaced with the uid attribute of the new multi-attribute data-source paramater.