### PR TITLE
Remove use of data-source-name templating variable

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -57,7 +57,7 @@ Add a panel to the `_panels` attribute to your dashboard and restart Promtimer.
 
 You'll see that you're new dashboard has a single empty panel.
 
-## Add a Target Parameterized by Data-Source-Name
+## Add a Target Parameterized by Data Source Name
 
 To add some time series to the panel, change the dashboard to look as follows and again restart.
 Let's also give the panel a better title:
@@ -71,9 +71,9 @@ Let's also give the panel a better title:
           "_base": "panel",
           "_targets": [
             {
-              "datasource": "{data-source-name}",
+              "datasource": "{data-source:name}",
               "expr": "sys_cpu_utilization_rate",
-              "legendFormat": "{data-source-name} sys_cpu_utilization_rate",
+              "legendFormat": "{data-source:name} sys_cpu_utilization_rate",
               "_base": "target"
             }
           ]
@@ -84,12 +84,12 @@ Let's also give the panel a better title:
 You will notice that the panel now contains one or more time series traces, or targets. Each target
 is the `sys_cpu_utilization_rate` for one of the cbcollects against which Promtimer is run. This
 happens because the target contains at least one instance of the Promtimer template parameter
-`{data-source-name}` which is automatically expanded by Promtimer to add one trace per data source,
+`{data-source:name}` which is automatically expanded by Promtimer to add one trace per data source,
 or cbcollect.
 
 ## Make the Panel Data-Source-Name Parameterized
 
-Add a data-source-name parameter to the panel, as follows:
+Add a data-source:name parameter to the panel, as follows:
 
     {
       "title": "New Dashboard",
@@ -97,13 +97,13 @@ Add a data-source-name parameter to the panel, as follows:
       "_panels": [
         {
           "title": "sys_cpu_utilization_rate",
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "_base": "panel",
           "_targets": [
             {
-              "datasource": "{data-source-name}",
+              "datasource": "{data-source:name}",
               "expr": "sys_cpu_utilization_rate",
-              "legendFormat": "{data-source-name} sys_cpu_utilization_rate",
+              "legendFormat": "{data-source:name} sys_cpu_utilization_rate",
               "_base": "target"
             }
           ]
@@ -111,7 +111,7 @@ Add a data-source-name parameter to the panel, as follows:
       ]
     }
 
-You'll notice that adding the data-source-name parameter to the panel caused the template expansion
+You'll notice that adding the data-source:name parameter to the panel caused the template expansion
 to occur at the panel level and you now have two panels, one for each data source.
 
 

--- a/dashboards/backup-service.json
+++ b/dashboards/backup-service.json
@@ -61,9 +61,9 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by(repository, task_type) (backup_task_run)",
-          "legendFormat": "{data-source-name} {{repository}} {{task_type}}",
+          "legendFormat": "{data-source:name} {{repository}} {{task_type}}",
           "_base": "target"
         }
       ]
@@ -77,9 +77,9 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by(repository, task_type) (backup_task_run{result=\"failure\"})",
-          "legendFormat": "{data-source-name} {{repository}} {{task_type}}",
+          "legendFormat": "{data-source:name} {{repository}} {{task_type}}",
           "_base": "target"
         }
       ]
@@ -93,9 +93,9 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by(repository) (backup_dispatched)",
-          "legendFormat": "{data-source-name} {{repository}}",
+          "legendFormat": "{data-source:name} {{repository}}",
           "_base": "target"
         }
       ]
@@ -109,9 +109,9 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by(repository) (backup_dispatched{result=\"failure\"})",
-          "legendFormat": "{data-source-name} {{repository}}",
+          "legendFormat": "{data-source:name} {{repository}}",
           "_base": "target"
         }
       ]
@@ -125,9 +125,9 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by(repository, task_type) (backup_task_duration_seconds_sum)",
-          "legendFormat": "{data-source-name} {{repository}} {{task_type}}",
+          "legendFormat": "{data-source:name} {{repository}} {{task_type}}",
           "_base": "target"
         }
       ]
@@ -146,9 +146,9 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by(repository) (backup_data_size)",
-          "legendFormat": "{data-source-name} {{repository}}",
+          "legendFormat": "{data-source:name} {{repository}}",
           "_base": "target"
         }
       ]
@@ -162,9 +162,9 @@
       },
       "targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by(repository) (backup_location_check)",
-          "legendFormat": "{data-source-name} {{repository}}",
+          "legendFormat": "{data-source:name} {{repository}}",
           "_base": "target"
         }
       ]

--- a/dashboards/bucket-overview.json
+++ b/dashboards/bucket-overview.json
@@ -62,9 +62,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ops{bucket=\"$bucket\"}[1m]))",
-          "legendFormat": "{data-source-name} sum(irate(kv_ops[1m]))",
+          "legendFormat": "{data-source:name} sum(irate(kv_ops[1m]))",
           "_base": "target"
         }
       ]
@@ -74,9 +74,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_total_resp_errors{bucket=\"$bucket\"}[1m]))",
-          "legendFormat": "{data-source-name} sum(irate(kv_total_resp_errors[1m]))",
+          "legendFormat": "{data-source:name} sum(irate(kv_total_resp_errors[1m]))",
           "_base": "target"
         }
       ]
@@ -86,9 +86,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.90, irate(kv_cmd_duration_seconds_bucket{opcode=\"GET\",bucket=\"$bucket\"}[5m]))",
-          "legendFormat": "{data-source-name} GET latency",
+          "legendFormat": "{data-source:name} GET latency",
           "_base": "target"
         }
       ]
@@ -98,9 +98,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(kv_ep_bg_fetched{bucket=\"$bucket\"}[1m])",
-          "legendFormat": "{data-source-name} irate(kv_ep_bg_fetched[1m]))",
+          "legendFormat": "{data-source:name} irate(kv_ep_bg_fetched[1m]))",
           "_base": "target"
         }
       ]
@@ -110,9 +110,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_ep_diskqueue_items{bucket=\"$bucket\"}",
-          "legendFormat": "{data-source-name} kv_ep_diskqueue_items",
+          "legendFormat": "{data-source:name} kv_ep_diskqueue_items",
           "_base": "target"
         }
       ]
@@ -122,9 +122,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(kv_vb_ops_create{bucket=\"$bucket\",state=\"active\"}[1m])",
-          "legendFormat": "{data-source-name} irate(kv_vb_ops_create{state=active}[1m])",
+          "legendFormat": "{data-source:name} irate(kv_vb_ops_create{state=active}[1m])",
           "_base": "target"
         }
       ]
@@ -134,9 +134,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_vb_perc_mem_resident_ratio{bucket=\"$bucket\"}",
-          "legendFormat": "{data-source-name} {{state}}",
+          "legendFormat": "{data-source:name} {{state}}",
           "_base": "target"
         }
       ],
@@ -148,8 +148,8 @@
       }
     },
     {
-      "title": "{data-source-name} irate(kv_ops[1m])",
-      "datasource": "{data-source-name}",
+      "title": "{data-source:name} irate(kv_ops[1m])",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -169,31 +169,31 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_mem_used_bytes{bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} mem_used",
+          "legendFormat": "{data-source:name} mem_used",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_ep_mem_high_wat{bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} high watermark",
+          "legendFormat": "{data-source:name} high watermark",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_ep_mem_low_wat{bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} low watermark",
+          "legendFormat": "{data-source:name} low watermark",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_resident{proc=\"memcached\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} memcached RSS",
+          "legendFormat": "{data-source:name} memcached RSS",
           "_base": "target"
         }
       ]
@@ -208,10 +208,10 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_ep_db_data_size_bytes",
           "interval": "",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ]
@@ -221,10 +221,10 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_vb_curr_items{state=~\"active|replica\",bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} {{state}}",
+          "legendFormat": "{data-source:name} {{state}}",
           "_base": "target"
         }
       ]
@@ -234,7 +234,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "(irate(kv_ops{op=~\"set|set_meta|set_ret_meta|cas|decr|del_meta|del_ret_meta|incr|delete\",bucket=\"$bucket\"}[5m]))",
           "legendFormat": "{{op}}-{{result}}",
           "_base": "target"
@@ -247,10 +247,10 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_ep_diskqueue_items{bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} disk queue",
+          "legendFormat": "{data-source:name} disk queue",
           "_base": "target"
         }
       ]
@@ -260,24 +260,24 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_curr_items_tot{bucket=\"$bucket\"} - ignoring(name) kv_ep_num_non_resident{bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} Items Resident (a+r) {{bucket}}",
+          "legendFormat": "{data-source:name} Items Resident (a+r) {{bucket}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_vb_curr_items{state=\"replica\",bucket=\"$bucket\"} - ignoring(name) kv_vb_num_non_resident{state=\"replica\",bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} Replica Items Resident {{bucket}}",
+          "legendFormat": "{data-source:name} Replica Items Resident {{bucket}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_vb_curr_items{state=\"active\",bucket=\"$bucket\"} - ignoring(name) kv_vb_num_non_resident{state=\"active\",bucket=\"$bucket\"}",
           "interval": "",
-          "legendFormat": "{data-source-name} Active Items Resident {{bucket}}",
+          "legendFormat": "{data-source:name} Active Items Resident {{bucket}}",
           "_base": "target"
         }
       ]

--- a/dashboards/chronicle-cluster.json
+++ b/dashboards/chronicle-cluster.json
@@ -39,9 +39,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum without (op) (cm_chronicle_disk_latency_seconds_bucket{le=\"+Inf\"} - ignoring(le) cm_chronicle_disk_latency_seconds_bucket{le=\"1.0\"})",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ]
@@ -51,9 +51,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum without (op) (irate(cm_chronicle_disk_latency_seconds_count[5m]))",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -64,9 +64,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "1000 * irate(cm_chronicle_disk_latency_seconds_sum{op=\"sync\"}[5m]) / ignoring(name) irate(cm_chronicle_disk_latency_seconds_count{op=\"sync\"}[5m])",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -77,9 +77,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(cm_chronicle_append_num_total[5m])",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -90,9 +90,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "cm_chronicle_append_batch_size_1m_max",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ]

--- a/dashboards/chronicle-node.json
+++ b/dashboards/chronicle-node.json
@@ -55,7 +55,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "cm_chronicle_disk_latency_seconds_bucket{le=\"+Inf\"} - ignoring(le) cm_chronicle_disk_latency_seconds_bucket{le=\"1.0\"}",
           "legendFormat": "{{op}}",
           "_base": "target"
@@ -67,7 +67,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(cm_chronicle_disk_latency_seconds_count[5m])",
           "legendFormat": "{{op}}",
           "_base": "target"
@@ -81,7 +81,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "1000 * irate(cm_chronicle_disk_latency_seconds_sum{op=\"sync\"}[5m]) / ignoring(name) irate(cm_chronicle_disk_latency_seconds_count{op=\"sync\"}[5m])",
           "_base": "target"
         }
@@ -98,7 +98,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by (le)(increase(cm_chronicle_disk_latency_seconds_bucket{op=\"sync\"}[5m]))",
           "legendFormat": "{{le}}",
           "format": "heatmap",
@@ -110,11 +110,11 @@
     },
     {
       "title": "number of chronicle appends / s",
-      "legendFormat": "{data-source-name}",
+      "legendFormat": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(cm_chronicle_append_num_total[5m])",
           "_base": "target"
         }
@@ -127,7 +127,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "cm_chronicle_append_batch_size_1m_max",
           "_base": "target"
         }

--- a/dashboards/cluster-overview.json
+++ b/dashboards/cluster-overview.json
@@ -39,9 +39,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_cpu_utilization_rate",
-          "legendFormat": "{data-source-name} sys_cpu_utilization_rate",
+          "legendFormat": "{data-source:name} sys_cpu_utilization_rate",
           "_base": "target"
         }
       ],
@@ -65,15 +65,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_mem_limit",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_mem_actual_used",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -97,9 +97,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_mem_free",
-          "legendFormat": "{data-source-name} sys_mem_free",
+          "legendFormat": "{data-source:name} sys_mem_free",
           "_base": "target"
         }
       ],
@@ -123,9 +123,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ops[1m]))",
-          "legendFormat": "{data-source-name} sum(irate(kv_ops[1m]))",
+          "legendFormat": "{data-source:name} sum(irate(kv_ops[1m]))",
           "_base": "target"
         }
       ],
@@ -149,15 +149,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ops{op=\"get\"}[1m]))",
-          "legendFormat": "{data-source-name} sum(irate(kv_ops{op=get}[1m]))",
+          "legendFormat": "{data-source:name} sum(irate(kv_ops{op=get}[1m]))",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ops{op=~\"set|set_meta|set_ret_meta|cas|decr|del_meta|del_ret_meta|incr|delete\"}[1m]))",
-          "legendFormat": "{data-source-name} sum(irate(kv_ops{op=~set|set_meta|cas|delete|...}[1m]))",
+          "legendFormat": "{data-source:name} sum(irate(kv_ops{op=~set|set_meta|cas|delete|...}[1m]))",
           "_base": "target"
         }
       ],
@@ -181,9 +181,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(kv_mem_used_bytes)",
-          "legendFormat": "{data-source-name} sum(kv_mem_used_bytes)",
+          "legendFormat": "{data-source:name} sum(kv_mem_used_bytes)",
           "_base": "target"
         }
       ],
@@ -207,9 +207,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(n1ql_requests[1m])",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -233,21 +233,21 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(n1ql_selects[1m])",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(n1ql_updates[1m])",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(n1ql_inserts[1m])",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -271,9 +271,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(index_items_count)",
-          "legendFormat": "{data-source-name} sum(index_items_count)",
+          "legendFormat": "{data-source:name} sum(index_items_count)",
           "_base": "target"
         }
       ],
@@ -297,9 +297,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(index_num_rows_scanned[1m]))",
-          "legendFormat": "{data-source-name} sum(irate(index_num_rows_scanned[1m]))",
+          "legendFormat": "{data-source:name} sum(irate(index_num_rows_scanned[1m]))",
           "_base": "target"
         }
       ],
@@ -323,9 +323,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(index_memory_used)",
-          "legendFormat": "{data-source-name} sum(index_memory_used)",
+          "legendFormat": "{data-source:name} sum(index_memory_used)",
           "_base": "target"
         }
       ],
@@ -349,9 +349,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(couch_docs_actual_disk_size)",
-          "legendFormat": "{data-source-name} sum(couch_docs_actual_disk_size)",
+          "legendFormat": "{data-source:name} sum(couch_docs_actual_disk_size)",
           "_base": "target"
         }
       ],

--- a/dashboards/contbk-nodebucket.json
+++ b/dashboards/contbk-nodebucket.json
@@ -43,7 +43,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "contbk_vbuckets_watched{bucket=\"$bucket\"}",
           "legendFormat": "__auto",
           "_base": "target"
@@ -60,7 +60,7 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "avg(rate(contbk_backed_up_bytes{bucket=\"$bucket\"}[1m]))",
           "legendFormat": "__auto",
           "_base": "target"
@@ -77,7 +77,7 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "contbk_backed_up_bytes{bucket=\"$bucket\"}",
           "legendFormat": "__auto",
           "_base": "target"
@@ -89,7 +89,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "contbk_backed_up_parts{bucket=\"$bucket\"}",
           "legendFormat": "__auto",
           "_base": "target"
@@ -101,7 +101,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "contbk_worker_queue_length{bucket=\"$bucket\"}",
           "legendFormat": "__auto",
           "_base": "target"
@@ -119,7 +119,7 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "format": "heatmap",
           "expr": "contbk_backed_up_part_size_bucket{bucket=\"$bucket\"}",
           "legendFormat": "__auto",
@@ -138,7 +138,7 @@
       },
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "format": "heatmap",
           "expr": "contbk_backed_up_part_time_bucket{bucket=\"$bucket\"}",
           "legendFormat": "__auto",

--- a/dashboards/kv-cluster.json
+++ b/dashboards/kv-cluster.json
@@ -72,9 +72,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_cpu_utilization{proc=\"memcached\"}",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -99,9 +99,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_uptime_seconds",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -126,9 +126,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_resident{proc=\"memcached\"}",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -152,9 +152,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(couch_docs_actual_disk_size)",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -181,9 +181,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ops[1m]))",
-          "legendFormat": "{data-source-name} {sum(irate(kv_ops[1m]))",
+          "legendFormat": "{data-source:name} {sum(irate(kv_ops[1m]))",
           "_base": "target"
         }
       ],
@@ -208,15 +208,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ops{op=\"get\"}[1m]))",
-          "legendFormat": "{data-source-name} GETS",
+          "legendFormat": "{data-source:name} GETS",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ops{op=~\"set|set_meta|set_ret_meta|cas|decr|del_meta|del_ret_meta|incr|delete\"}[1m]))",
-          "legendFormat": "{data-source-name} MUTATIONS",
+          "legendFormat": "{data-source:name} MUTATIONS",
           "_base": "target"
         }
       ],
@@ -241,9 +241,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ep_bg_fetched[5m]))",
-          "legendFormat": "{data-source-name} BG Fetches",
+          "legendFormat": "{data-source:name} BG Fetches",
           "_base": "target"
         }
       ],
@@ -268,21 +268,21 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.99, sum by (le) (irate(kv_cmd_duration_seconds_bucket{opcode=~\"GET|GAT\"}[10m])))",
-          "legendFormat": "99th {data-source-name} GET/GAT",
+          "legendFormat": "99th {data-source:name} GET/GAT",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.90, sum by (le) (irate(kv_cmd_duration_seconds_bucket{opcode=~\"GET|GAT\"}[10m])))",
-          "legendFormat": "90th {data-source-name} GET/GAT",
+          "legendFormat": "90th {data-source:name} GET/GAT",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.50, sum by (le) (irate(kv_cmd_duration_seconds_bucket{opcode=~\"GET|GAT\"}[10m])))",
-          "legendFormat": "50th {data-source-name} GET/GAT",
+          "legendFormat": "50th {data-source:name} GET/GAT",
           "_base": "target"
         }
       ],
@@ -307,15 +307,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.99, sum by (le) (irate(kv_sync_write_commit_duration_seconds_bucket{level=\"persist_to_majority\"}[5m])))",
-          "legendFormat": "99th {data-source-name} Sync SET",
+          "legendFormat": "99th {data-source:name} Sync SET",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.50, sum by (le) (irate(kv_sync_write_commit_duration_seconds_bucket{level=\"persist_to_majority\"}[5m])))",
-          "legendFormat": "50th {data-source-name} Sync SET",
+          "legendFormat": "50th {data-source:name} Sync SET",
           "_base": "target"
         }
       ],
@@ -340,15 +340,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.99, sum by (le) (irate(kv_cmd_duration_seconds_bucket{opcode=\"SET\"}[10m])))",
-          "legendFormat": "99th {data-source-name} Sync SET",
+          "legendFormat": "99th {data-source:name} Sync SET",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.50, sum by (le) (irate(kv_cmd_duration_seconds_bucket{opcode=\"SET\"}[10m])))",
-          "legendFormat": "50th {data-source-name} Sync SET",
+          "legendFormat": "50th {data-source:name} Sync SET",
           "_base": "target"
         }
       ],
@@ -377,9 +377,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ep_total_enqueued[5m]))",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -404,15 +404,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ep_total_deduplicated[5m]))",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ep_total_deduplicated_flusher[5m]))",
-          "legendFormat": "{data-source-name}:flusher",
+          "legendFormat": "{data-source:name}:flusher",
           "_base": "target"
         }
       ],
@@ -437,15 +437,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(kv_ep_db_data_size_bytes)",
-          "legendFormat": "{data-source-name}:db_data_size",
+          "legendFormat": "{data-source:name}:db_data_size",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(kv_ep_magma_logical_data_size_bytes)",
-          "legendFormat": "{data-source-name}:magma_logical_data_size",
+          "legendFormat": "{data-source:name}:magma_logical_data_size",
           "_base": "target"
         }
       ],
@@ -470,9 +470,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_ep_magma_history_logical_data_size_bytes",
-          "legendFormat": "{data-source-name}:history_size",
+          "legendFormat": "{data-source:name}:history_size",
           "_base": "target"
         }
       ],
@@ -497,9 +497,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_ep_magma_history_logical_disk_size_bytes",
-          "legendFormat": "{data-source-name}:history_size",
+          "legendFormat": "{data-source:name}:history_size",
           "_base": "target"
         }
       ],
@@ -524,9 +524,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(kv_ep_db_history_file_size_bytes)",
-          "legendFormat": "{data-source-name}:history_size",
+          "legendFormat": "{data-source:name}:history_size",
           "_base": "target"
         }
       ],
@@ -551,9 +551,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "((kv_ep_db_file_size_bytes - on (bucket) (kv_ep_db_history_file_size_bytes or on (bucket) kv_ep_db_file_size_bytes * 0)) - on (bucket) kv_ep_db_data_size_bytes)",
-          "legendFormat": "{data-source-name}:{{bucket}}:fragmentation",
+          "legendFormat": "{data-source:name}:{{bucket}}:fragmentation",
           "_base": "target"
         }
       ],
@@ -578,9 +578,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "((kv_ep_db_file_size_bytes - on (bucket) (kv_ep_db_history_file_size_bytes or on (bucket) kv_ep_db_file_size_bytes * 0)) - on (bucket) kv_ep_db_data_size_bytes) / on (bucket) (kv_ep_db_file_size_bytes - on (bucket) (kv_ep_db_history_file_size_bytes or on (bucket) kv_ep_db_file_size_bytes * 0))",
-          "legendFormat": "{data-source-name}:{{bucket}}:fragmentation",
+          "legendFormat": "{data-source:name}:{{bucket}}:fragmentation",
           "_base": "target"
         }
       ],
@@ -609,9 +609,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(kv_dcp_items_sent)",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -636,9 +636,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_dcp_items_sent[5m]))",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -663,9 +663,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(kv_dcp_total_data_size_bytes)",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -690,9 +690,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_dcp_total_data_size_bytes[5m]))",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -721,9 +721,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_total_connections",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -748,9 +748,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(kv_curr_connections) + sum(kv_daemon_connections) + sum(kv_system_connections)",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -780,9 +780,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_audit_enabled",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -808,9 +808,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "kv_audit_dropped_events",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],

--- a/dashboards/kv-node.json
+++ b/dashboards/kv-node.json
@@ -88,7 +88,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by (bucket) (irate(kv_ops[5m]))",
           "legendFormat": "{{bucket}}",
           "_base": "target"
@@ -104,7 +104,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by (bucket) (irate(kv_ops{op=\"get\"}[5m]))",
           "legendFormat": "{{bucket}}",
           "_base": "target"
@@ -120,7 +120,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by (bucket) (irate(kv_ops{op=~\"set|set_meta|set_ret_meta|cas|decr|del_meta|del_ret_meta|incr|delete\"}[5m]))",
           "legendFormat": "{{bucket}}",
           "_base": "target"
@@ -136,7 +136,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(kv_ep_bg_fetched[5m]))",
           "legendFormat": "BG Fetches",
           "_base": "target"
@@ -149,13 +149,13 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.90, sum by (le) (irate(kv_cmd_duration_seconds_bucket{opcode=~\"GET|GAT\"}[10m])))",
           "legendFormat": "90th GET/GAT",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.50, sum by (le) (irate(kv_cmd_duration_seconds_bucket{opcode=~\"GET|GAT\"}[10m])))",
           "legendFormat": "50th GET/GAT",
           "_base": "target"
@@ -173,7 +173,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "topk(5, sum by (opcode) (kv_cmd_duration_seconds_count{opcode!~\"DCP.*\"}))",
           "legendFormat": "{{opcode}}",
           "_base": "target"
@@ -186,7 +186,7 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "exposer_request_latencies{quantile=\"0.990000\"}",
           "legendFormat": "99th {{job}}",
           "_base": "target"
@@ -232,7 +232,7 @@
     },
     {
       "title": "Data Read Failures",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -245,7 +245,7 @@
     },
     {
       "title": "Data Write Failures",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -258,7 +258,7 @@
     },
     {
       "title": "Doc Size",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -282,7 +282,7 @@
     },
     {
       "title": "Number of Docs (inc. Replicas)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -306,7 +306,7 @@
     },
     {
       "title": "Percentage Memory Resident",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -330,7 +330,7 @@
     },
     {
       "title": "Compaction write & read bytes",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -359,7 +359,7 @@
     },
     {
       "title": "Rate of Deletes",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -372,7 +372,7 @@
     },
     {
       "title": "Rate of Doc Expirations",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -385,7 +385,7 @@
     },
     {
       "title": "Rollback Item Count",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -399,7 +399,7 @@
     {
       "title": "Size of Key",
       "type": "stat",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -416,7 +416,7 @@
     },
     {
       "title": "Data Size",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -429,7 +429,7 @@
     },
     {
       "title": "Disk Queue Items",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -442,7 +442,7 @@
     },
     {
       "title": "Disk Queue Memory Usage",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -455,7 +455,7 @@
     },
     {
       "title": "New and Persisted Items",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -468,7 +468,7 @@
     },
     {
       "title": "Written Bytes over All Network Interfaces (including Loopback)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 6
       },
@@ -484,7 +484,7 @@
     },
     {
       "title": "Read Bytes over All Network Interfaces (including Loopback)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 6
       },
@@ -504,7 +504,7 @@
     },
     {
       "title": "KV CPU Utilization",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -517,7 +517,7 @@
     },
     {
       "title": "KV CPU Utilization By Thread",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -539,7 +539,7 @@
     },
     {
       "title": "Failed KV Operations",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -552,7 +552,7 @@
     },
     {
       "title": "KV Operations",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -566,7 +566,7 @@
     },
     {
       "title": "KV Uptime",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -579,7 +579,7 @@
     },
     {
       "title": "KV Memory Usage",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -596,7 +596,7 @@
     },
     {
       "title": "Checkpoint Memory Size",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -610,7 +610,7 @@
     {
       "title": "Defragmenter Enabled",
       "type": "bargauge",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -639,7 +639,7 @@
     {
       "title": "Defragmenter Interval",
       "type": "gauge",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -665,7 +665,7 @@
     },
     {
       "title": "Metadata Overhead",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -678,7 +678,7 @@
     },
     {
       "title": "OOM Errors Total",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -691,7 +691,7 @@
     },
     {
       "title": "OOM Errors at Warmup",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -708,7 +708,7 @@
     },
     {
       "title": "Backoff Events",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -722,7 +722,7 @@
     {
       "title": "Idle Timeout",
       "type": "gauge",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -748,7 +748,7 @@
     },
     {
       "title": "Producer Count",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -761,7 +761,7 @@
     },
     {
       "title": "Remaining Items",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -774,7 +774,7 @@
     },
     {
       "title": "Sent Items",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -787,7 +787,7 @@
     },
     {
       "title": "Total Connections",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -800,7 +800,7 @@
     },
     {
       "title": "Total Data Size",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -817,7 +817,7 @@
     },
     {
       "title": "vBucket Operations (Active)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8
       },
@@ -833,7 +833,7 @@
     },
     {
       "title": "vBucket Operations (Replica)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8
       },
@@ -849,7 +849,7 @@
     },
     {
       "title": "vBucket Operations (Pending)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8
       },
@@ -865,7 +865,7 @@
     },
     {
       "title": "Total",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -882,7 +882,7 @@
     },
     {
       "title": "Memory Used by Collection",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -896,7 +896,7 @@
     },
     {
       "title": "Operations Run on Collection",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -913,7 +913,7 @@
     },
     {
       "title": "Connections Ever Opened",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -926,7 +926,7 @@
     },
     {
       "title": "Current Connections",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -955,7 +955,7 @@
     },
     {
       "title": "Number of Auth Errors",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -968,7 +968,7 @@
     },
     {
       "title": "Data/History Size",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -997,7 +997,7 @@
     },
     {
       "title": "Fragmentation (couch_docs_fragmentation)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {

--- a/dashboards/magma-cluster.json
+++ b/dashboards/magma-cluster.json
@@ -10,9 +10,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(rate(kv_ep_magma_gets[1m]))",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -25,9 +25,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(rate(kv_ep_magma_sets[1m]))",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -40,9 +40,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(rate(kv_ep_magma_inserts[1m]))",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -55,9 +55,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(kv_ep_magma_total_mem_used_bytes)",
-                   "legendFormat": "{data-source-name}",
+                   "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -75,9 +75,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(rate(kv_ep_magma_write_bytes_bytes[1m]))",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -90,9 +90,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(kv_ep_magma_write_bytes_bytes)",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -105,9 +105,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(rate(kv_ep_magma_bytes_incoming_bytes[1m]))",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -120,9 +120,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(kv_ep_magma_bytes_incoming_bytes)",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -135,9 +135,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(rate(kv_ep_magma_read_bytes_bytes[1m]))",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -150,9 +150,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(kv_ep_magma_read_bytes_bytes)",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -165,9 +165,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(rate(kv_ep_magma_bytes_outgoing_bytes[1m]))",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -180,9 +180,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(kv_ep_magma_bytes_outgoing_bytes)",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]
@@ -200,9 +200,9 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum(kv_ep_magma_total_disk_usage_bytes)",
-                    "legendFormat": "{data-source-name}",
+                    "legendFormat": "{data-source:name}",
                     "_base": "target"
                 }
             ]

--- a/dashboards/magma-node.json
+++ b/dashboards/magma-node.json
@@ -27,7 +27,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (rate(kv_ep_magma_gets[1m]))",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -42,7 +42,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (rate(kv_ep_magma_sets[1m]))",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -57,7 +57,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (rate(kv_ep_magma_inserts[1m]))",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -72,7 +72,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "kv_ep_magma_total_mem_used_bytes",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -87,7 +87,7 @@
             },
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "sum by (thread_pool) (rate(kv_thread_cpu_usage_seconds[6m]))",
                 "legendFormat": "{{label_name}}",
                 "_base": "target"
@@ -107,7 +107,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (rate(kv_ep_magma_write_bytes_bytes[1m]))",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -122,7 +122,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_write_bytes_bytes)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -137,7 +137,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (rate(kv_ep_magma_bytes_incoming_bytes[1m]))",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -152,7 +152,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_bytes_incoming_bytes)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -167,7 +167,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (rate(kv_ep_magma_read_bytes_bytes[1m]))",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -182,7 +182,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_read_bytes_bytes)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -197,7 +197,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (rate(kv_ep_magma_bytes_outgoing_bytes[1m]))",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -212,7 +212,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_bytes_outgoing_bytes)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -232,7 +232,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_total_disk_usage_bytes)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -247,7 +247,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_data_blocks_uncompressed_size)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -262,7 +262,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_data_blocks_compressed_size)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -277,7 +277,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_fragmentation_ratio*100)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -297,7 +297,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_history_size_evicted_bytes)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"
@@ -312,7 +312,7 @@
             },
             "_targets": [
                 {
-                    "datasource": "{data-source-name}",
+                    "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_history_time_evicted_bytes)",
                     "legendFormat": "{{bucket}}",
                     "_base": "target"

--- a/dashboards/node-overview.json
+++ b/dashboards/node-overview.json
@@ -53,7 +53,7 @@
   "_panels": [
     {
       "title": "sys_cpu_utilization_rate",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -71,7 +71,7 @@
     },
     {
       "title": "sysproc_cpu_utilization",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -88,7 +88,7 @@
     },
     {
       "title": "sys_cpu_host_seconds_total",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -101,7 +101,7 @@
     },
     {
       "title": "sysproc_mem_resident",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -118,7 +118,7 @@
     },
     {
       "title": "kv_curr_items",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -130,7 +130,7 @@
     },
     {
       "title": "sum(irate(kv_ops[1m]))",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -142,7 +142,7 @@
     },
     {
       "title": "kv gets and mutations",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -159,7 +159,7 @@
     },
     {
       "title": "total ops by bucket",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -171,7 +171,7 @@
     },
     {
       "title": "90th percentile GET latency",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -191,9 +191,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(cm_rest_request_leaves_total[1m])",
-          "legendFormat": "{data-source-name} sum(cm_rest_request_leaves_total[1m])",
+          "legendFormat": "{data-source:name} sum(cm_rest_request_leaves_total[1m])",
           "_base": "target"
         }
       ]
@@ -203,16 +203,16 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "cm_rest_request_enters_total - ignoring(name) cm_rest_request_leaves_total",
-          "legendFormat": "{data-source-name} cm_rest_request_enters_total - cm_rest_request_leaves_total",
+          "legendFormat": "{data-source:name} cm_rest_request_enters_total - cm_rest_request_leaves_total",
           "_base": "target"
         }
       ]
     },
     {
       "title": "90th percentile ns-server outgoing request latencies",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -229,7 +229,7 @@
     },
     {
       "title": "sys_mem_cgroup (limit/used)",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -252,7 +252,7 @@
     {
       "title": "sys_disk_read_bytes (per second)",
       "description": "The number of bytes read from disk per second.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -270,7 +270,7 @@
     {
       "title": "sys_disk_write_bytes (per second)",
       "description": "The number of bytes written to disk per second.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -288,7 +288,7 @@
     {
       "title": "sys_disk_reads (per second)",
       "description": "Disk read operations per second.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -301,7 +301,7 @@
     {
       "title": "sys_disk_writes (per second)",
       "description": "Disk write operations per second.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -314,7 +314,7 @@
     {
       "title": "sys_disk_read_time",
       "description": "Amount of time disk spent reading.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -332,7 +332,7 @@
     {
       "title": "sys_disk_write_time",
       "description": "Amount of time disk spent writing.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {
@@ -350,7 +350,7 @@
     {
       "title": "sys_disk_queue",
       "description": "Current disk queue length.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "_base": "panel",
       "_targets": [
         {

--- a/dashboards/ns-server-dashboard.json
+++ b/dashboards/ns-server-dashboard.json
@@ -43,9 +43,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_cpu_utilization_rate",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -69,15 +69,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_cpu_utilization_rate * ignoring(name)sys_cpu_cores_available",
-          "legendFormat": "{data-source-name} sys_cpu_utilization_rate (in cores)",
+          "legendFormat": "{data-source:name} sys_cpu_utilization_rate (in cores)",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_cpu_utilization{proc=\"ns_server\"}",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         }
       ],
@@ -101,9 +101,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_cpu_stolen_rate",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -127,9 +127,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_cpu_irq_rate",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -153,9 +153,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_cpu_cores_available",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -183,9 +183,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_resident{proc=\"ns_server\"}",
-          "legendFormat": "{data-source-name}",
+          "legendFormat": "{data-source:name}",
           "_base": "target"
         }
       ],
@@ -209,15 +209,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_mem_limit",
-          "legendFormat": "{data-source-name} sys_mem_limit",
+          "legendFormat": "{data-source:name} sys_mem_limit",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_mem_actual_used",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -241,15 +241,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_size{proc=\"ns_server\"}",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_resident{proc=\"ns_server\"}",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         }
       ],
@@ -273,9 +273,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_major_faults_raw{proc=\"ns_server\"}",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -299,9 +299,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(sysproc_major_faults_raw{proc=\"ns_server\"}[1m])",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         }
       ],
@@ -325,9 +325,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(sysproc_minor_faults_raw{proc=\"ns_server\"}[1m])",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         }
       ],
@@ -351,9 +351,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_allocstall",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -377,9 +377,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(sys_allocstall[1m])",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -403,15 +403,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_swap_total",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_swap_used",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -439,9 +439,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(cm_rest_request_leaves_total[1m])",
-          "legendFormat": "{data-source-name} sum(cm_rest_request_leaves_total[1m])",
+          "legendFormat": "{data-source:name} sum(cm_rest_request_leaves_total[1m])",
           "_base": "target"
         }
       ],
@@ -465,9 +465,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "cm_rest_request_enters_total - ignoring(name) cm_rest_request_leaves_total",
-          "legendFormat": "{data-source-name} cm_rest_request_enters_total - cm_rest_request_leaves_total",
+          "legendFormat": "{data-source:name} cm_rest_request_enters_total - cm_rest_request_leaves_total",
           "_base": "target"
         }
       ],
@@ -491,9 +491,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum(irate(cm_http_requests_total[5m]))",
-          "legendFormat": "{data-source-name} sum(irate(cm_http_requests_total[5m]))",
+          "legendFormat": "{data-source:name} sum(irate(cm_http_requests_total[5m]))",
           "_base": "target"
         }
       ],
@@ -517,15 +517,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(cm_request_hibernates_total[5m])",
-          "legendFormat": "{data-source-name} irate(cm_request_hibernates_total[5m])",
+          "legendFormat": "{data-source:name} irate(cm_request_hibernates_total[5m])",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(cm_request_unhibernates_total[5m])",
-          "legendFormat": "{data-source-name} irate(cm_request_unhibernates_total[5m])",
+          "legendFormat": "{data-source:name} irate(cm_request_unhibernates_total[5m])",
           "_base": "target"
         }
       ],
@@ -553,9 +553,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "cm_ns_config_merger_queue_len_1m_max",
-          "legendFormat": "{data-source-name} {{name}}",
+          "legendFormat": "{data-source:name} {{name}}",
           "_base": "target"
         }
       ],
@@ -579,21 +579,21 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.999, irate(cm_timer_lag_seconds_bucket[5m]))",
-          "legendFormat": "{data-source-name} timer_lag 99.9th percentile",
+          "legendFormat": "{data-source:name} timer_lag 99.9th percentile",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.9, irate(cm_timer_lag_seconds_bucket[5m]))",
-          "legendFormat": "{data-source-name} timer_lag 90th percentile",
+          "legendFormat": "{data-source:name} timer_lag 90th percentile",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "histogram_quantile(0.5, irate(cm_timer_lag_seconds_bucket[5m]))",
-          "legendFormat": "{data-source-name} timer_lag 50th percentile",
+          "legendFormat": "{data-source:name} timer_lag 50th percentile",
           "_base": "target"
         }
       ],
@@ -621,9 +621,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_pressure_share_time_stalled{resource=\"cpu\",level=\"host\"}",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -647,9 +647,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_pressure_total_stall_time_usec{resource=\"cpu\",level=\"host\"}/1000",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -673,9 +673,9 @@
       "_base": "panel",
       "_targets": [
           {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(sys_pressure_total_stall_time_usec{resource=\"cpu\",level=\"host\"}[1m])/1000",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -699,9 +699,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_pressure_share_time_stalled{resource=\"memory\",level=\"host\"}",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -725,9 +725,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_pressure_total_stall_time_usec{resource=\"memory\",level=\"host\"}/1000",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -751,9 +751,9 @@
       "_base": "panel",
       "_targets": [
           {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(sys_pressure_total_stall_time_usec{resource=\"memory\",level=\"host\"}[1m])/1000",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -777,9 +777,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_pressure_share_time_stalled{resource=\"io\",level=\"host\"}",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -803,9 +803,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sys_pressure_total_stall_time_usec{resource=\"io\",level=\"host\"}/1000",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],
@@ -829,9 +829,9 @@
       "_base": "panel",
       "_targets": [
           {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(sys_pressure_total_stall_time_usec{resource=\"io\",level=\"host\"}[1m])/1000",
-          "legendFormat": "{data-source-name} {{level}} {{quantifier}} {{interval}}",
+          "legendFormat": "{data-source:name} {{level}} {{quantifier}} {{interval}}",
           "_base": "target"
         }
       ],

--- a/dashboards/search-dashboard.json
+++ b/dashboards/search-dashboard.json
@@ -39,9 +39,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_bytes_used_ram",
-                "legendFormat": "{data-source-name} fts_num_bytes_used_ram",
+                "legendFormat": "{data-source:name} fts_num_bytes_used_ram",
                 "_base": "target"
               }
             ]
@@ -51,9 +51,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_bytes_used_ram_c",
-                "legendFormat": "{data-source-name} fts_num_bytes_used_ram_c",
+                "legendFormat": "{data-source:name} fts_num_bytes_used_ram_c",
                 "_base": "target"
               }
             ]
@@ -63,9 +63,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_curr_batches_blocked_by_herder",
-                "legendFormat": "{data-source-name} fts_curr_batches_blocked_by_herder",
+                "legendFormat": "{data-source:name} fts_curr_batches_blocked_by_herder",
                 "_base": "target"
               }
             ]
@@ -75,9 +75,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_avg_queries_latency",
-                "legendFormat": "{data-source-name} fts_avg_queries_latency",
+                "legendFormat": "{data-source:name} fts_avg_queries_latency",
                 "_base": "target"
               }
             ]
@@ -87,9 +87,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_root_memorysegments",
-                "legendFormat": "{data-source-name} fts_num_root_memorysegments",
+                "legendFormat": "{data-source:name} fts_num_root_memorysegments",
                 "_base": "target"
               }
             ]
@@ -99,9 +99,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_root_filesegments",
-                "legendFormat": "{data-source-name} fts_num_root_filesegments",
+                "legendFormat": "{data-source:name} fts_num_root_filesegments",
                 "_base": "target"
               }
             ]
@@ -111,9 +111,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_tot_queryreject_on_memquota",
-                "legendFormat": "{data-source-name} fts_tot_queryreject_on_memquota",
+                "legendFormat": "{data-source:name} fts_tot_queryreject_on_memquota",
                 "_base": "target"
               }
             ]
@@ -123,9 +123,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_tot_grpc_queryreject_on_memquota",
-                "legendFormat": "{data-source-name} fts_tot_grpc_queryreject_on_memquota",
+                "legendFormat": "{data-source:name} fts_tot_grpc_queryreject_on_memquota",
                 "_base": "target"
               }
             ]
@@ -135,9 +135,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_queries_rejected_by_herder",
-                "legendFormat": "{data-source-name} fts_total_queries_rejected_by_herder",
+                "legendFormat": "{data-source:name} fts_total_queries_rejected_by_herder",
                 "_base": "target"
               }
             ]
@@ -147,9 +147,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_batch_bytes_added",
-                "legendFormat": "{data-source-name} fts_batch_bytes_added",
+                "legendFormat": "{data-source:name} fts_batch_bytes_added",
                 "_base": "target"
               }
             ]
@@ -159,9 +159,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_batch_bytes_removed",
-                "legendFormat": "{data-source-name} fts_batch_bytes_removed",
+                "legendFormat": "{data-source:name} fts_batch_bytes_removed",
                 "_base": "target"
               }
             ]
@@ -171,9 +171,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_batches_introduced",
-                "legendFormat": "{data-source-name} fts_num_batches_introduced",
+                "legendFormat": "{data-source:name} fts_num_batches_introduced",
                 "_base": "target"
               }
             ]
@@ -183,9 +183,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_create_index_request",
-                "legendFormat": "{data-source-name} fts_total_create_index_request",
+                "legendFormat": "{data-source:name} fts_total_create_index_request",
                 "_base": "target"
               }
             ]
@@ -195,9 +195,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_delete_index_request",
-                "legendFormat": "{data-source-name} fts_total_delete_index_request",
+                "legendFormat": "{data-source:name} fts_total_delete_index_request",
                 "_base": "target"
               }
             ]
@@ -207,9 +207,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_files_on_disk",
-                "legendFormat": "{data-source-name} fts_num_files_on_disk",
+                "legendFormat": "{data-source:name} fts_num_files_on_disk",
                 "_base": "target"
               }
             ]
@@ -219,9 +219,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_pct_cpu_gc",
-                "legendFormat": "{data-source-name} fts_pct_cpu_gc",
+                "legendFormat": "{data-source:name} fts_pct_cpu_gc",
                 "_base": "target"
               }
             ]
@@ -231,9 +231,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_gc",
-                "legendFormat": "{data-source-name} fts_total_gc",
+                "legendFormat": "{data-source:name} fts_total_gc",
                 "_base": "target"
               }
             ]
@@ -243,9 +243,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_doc_count",
-                "legendFormat": "{data-source-name} fts_doc_count",
+                "legendFormat": "{data-source:name} fts_doc_count",
                 "_base": "target"
               }
             ]
@@ -255,9 +255,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_queries",
-                "legendFormat": "{data-source-name} fts_total_queries",
+                "legendFormat": "{data-source:name} fts_total_queries",
                 "_base": "target"
               }
             ]
@@ -267,9 +267,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_grpc_internal_queries",
-                "legendFormat": "{data-source-name} fts_total_grpc_internal_queries",
+                "legendFormat": "{data-source:name} fts_total_grpc_internal_queries",
                 "_base": "target"
               }
             ]
@@ -279,9 +279,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_queries_to_actives",
-                "legendFormat": "{data-source-name} fts_total_queries_to_actives",
+                "legendFormat": "{data-source:name} fts_total_queries_to_actives",
                 "_base": "target"
               }
             ]
@@ -291,9 +291,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_queries_to_replicas",
-                "legendFormat": "{data-source-name} fts_total_queries_to_replicas",
+                "legendFormat": "{data-source:name} fts_total_queries_to_replicas",
                 "_base": "target"
               }
             ]
@@ -303,9 +303,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_queries_error",
-                "legendFormat": "{data-source-name} fts_total_queries_error",
+                "legendFormat": "{data-source:name} fts_total_queries_error",
                 "_base": "target"
               }
             ]
@@ -315,9 +315,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_queries_timeout",
-                "legendFormat": "{data-source-name} fts_total_queries_timeout",
+                "legendFormat": "{data-source:name} fts_total_queries_timeout",
                 "_base": "target"
               }
             ]
@@ -327,9 +327,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_queries_slow",
-                "legendFormat": "{data-source-name} fts_total_queries_slow",
+                "legendFormat": "{data-source:name} fts_total_queries_slow",
                 "_base": "target"
               }
             ]
@@ -339,9 +339,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_bytes_used_disk",
-                "legendFormat": "{data-source-name} fts_num_bytes_used_disk",
+                "legendFormat": "{data-source:name} fts_num_bytes_used_disk",
                 "_base": "target"
               }
             ]
@@ -351,9 +351,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_knn_search_requests",
-                "legendFormat": "{data-source-name} fts_num_knn_search_requests",
+                "legendFormat": "{data-source:name} fts_num_knn_search_requests",
                 "_base": "target"
               }
             ]
@@ -363,9 +363,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_knn_searches",
-                "legendFormat": "{data-source-name} fts_total_knn_searches",
+                "legendFormat": "{data-source:name} fts_total_knn_searches",
                 "_base": "target"
               }
             ]
@@ -375,9 +375,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_vectors",
-                "legendFormat": "{data-source-name} fts_total_vectors",
+                "legendFormat": "{data-source:name} fts_total_vectors",
                 "_base": "target"
               }
             ]
@@ -387,9 +387,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_synonym_searches",
-                "legendFormat": "{data-source-name} fts_total_synonym_searches",
+                "legendFormat": "{data-source:name} fts_total_synonym_searches",
                 "_base": "target"
               }
             ]
@@ -399,9 +399,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_bytes_indexed",
-                "legendFormat": "{data-source-name} fts_total_bytes_indexed",
+                "legendFormat": "{data-source:name} fts_total_bytes_indexed",
                 "_base": "target"
               }
             ]
@@ -411,9 +411,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_mutations_to_index",
-                "legendFormat": "{data-source-name} fts_num_mutations_to_index",
+                "legendFormat": "{data-source:name} fts_num_mutations_to_index",
                 "_base": "target"
               }
             ]
@@ -423,9 +423,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_mutations_filtered",
-                "legendFormat": "{data-source-name} fts_total_mutations_filtered",
+                "legendFormat": "{data-source:name} fts_total_mutations_filtered",
                 "_base": "target"
               }
             ]
@@ -435,9 +435,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_recs_to_persist",
-                "legendFormat": "{data-source-name} fts_num_recs_to_persist",
+                "legendFormat": "{data-source:name} fts_num_recs_to_persist",
                 "_base": "target"
               }
             ]
@@ -447,9 +447,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_file_merge_ops",
-                "legendFormat": "{data-source-name} fts_num_file_merge_ops",
+                "legendFormat": "{data-source:name} fts_num_file_merge_ops",
                 "_base": "target"
               }
             ]
@@ -459,9 +459,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_num_mem_merge_ops",
-                "legendFormat": "{data-source-name} fts_num_mem_merge_ops",
+                "legendFormat": "{data-source:name} fts_num_mem_merge_ops",
                 "_base": "target"
               }
             ]
@@ -471,9 +471,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_term_searchers",
-                "legendFormat": "{data-source-name} fts_total_term_searchers",
+                "legendFormat": "{data-source:name} fts_total_term_searchers",
                 "_base": "target"
               }
             ]
@@ -483,9 +483,9 @@
             "_base": "panel",
             "_targets": [
               {
-                "datasource": "{data-source-name}",
+                "datasource": "{data-source:name}",
                 "expr": "fts_total_term_searchers_finished",
-                "legendFormat": "{data-source-name} fts_total_term_searchers_finished",
+                "legendFormat": "{data-source:name} fts_total_term_searchers_finished",
                 "_base": "target"
               }
             ]

--- a/dashboards/use-node.json
+++ b/dashboards/use-node.json
@@ -44,7 +44,7 @@
     {
       "title": "CPU Utilization",
       "description": "What did CPU(s) spent their time doing. Blues represent time that the system is doing work, yellow represents time waiting.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -151,7 +151,7 @@
     },
     {
       "title": "CPU Saturation",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -236,7 +236,7 @@
     {
       "_base": "text",
       "title": "CPU Errors",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -258,7 +258,7 @@
     {
       "title": "Memory Utilization",
       "description": "What is system memory being used for. Blues represent memory explicitly used by applications, yellows represent memory used by OS / on applications' behalf.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -329,7 +329,7 @@
     {
       "title": "Memory Saturation",
       "description": "Indicators that memory is saturated.  Swap Used: bytes of memory used by swap; generally this should be (close to) zero, increasing values can be a sign of problems.What is system memory being used for.\nAllocation Stalls: rate of Linux kernel allocation stalls, when a userspace thread is prevented from running due to memory allocation request which cannot be immediately satisfied due to low kernel memory. A non-zero value means userspace threads are being delayed due t memory pressure.",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -399,7 +399,7 @@
     {
       "_base": "text",
       "title": "Memory Errors",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -421,7 +421,7 @@
     {
       "title": "Network Utilization",
       "description": "Data read from (ingress) and written to (egress) the network in bits/s. Y axis scale: log(10).",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -490,7 +490,7 @@
     },
     {
       "title": "Network Saturation",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -510,7 +510,7 @@
     },
     {
       "title": "Network Errors",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -537,7 +537,7 @@
     {
       "title": "Disk Utilization",
       "description": "Y axis scale: log(10).",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -646,7 +646,7 @@
     },
     {
       "title": "Disk Saturation",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8
@@ -667,7 +667,7 @@
     {
       "_base": "text",
       "title": "Disk Errors",
-      "datasource": "{data-source-name}",
+      "datasource": "{data-source:name}",
       "gridPos": {
         "w": 8,
         "h": 8

--- a/dashboards/xdcr-dashboard.json
+++ b/dashboards/xdcr-dashboard.json
@@ -7,9 +7,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_changes_left_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_changes_left_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_changes_left_total",
           "_base": "target"
         }
       ]
@@ -19,9 +19,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_pipeline_errors",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_pipeline_errors",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_pipeline_errors",
           "_base": "target"
         }
       ]
@@ -31,9 +31,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_processed_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_processed_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_processed_total",
           "_base": "target"
         }
       ]
@@ -43,9 +43,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(xdcr_docs_processed_total[5m])",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_processed_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_processed_total",
           "_base": "target"
         }
       ]
@@ -55,9 +55,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_received_from_dcp_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_received_from_dcp_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_received_from_dcp_total",
           "_base": "target"
         }
       ]
@@ -67,9 +67,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(xdcr_docs_received_from_dcp_total[5m])",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_received_from_dcp_rate",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_received_from_dcp_rate",
           "_base": "target"
         }
       ]
@@ -79,9 +79,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_expiry_received_from_dcp_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_received_from_dcp_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_received_from_dcp_total",
           "_base": "target"
         }
       ]
@@ -91,9 +91,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_deletion_received_from_dcp_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_received_from_dcp_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_received_from_dcp_total",
           "_base": "target"
         }
       ]
@@ -103,9 +103,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_set_received_from_dcp_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_received_from_dcp_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_received_from_dcp_total",
           "_base": "target"
         }
       ]
@@ -115,9 +115,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_dcp_datach_length_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_dcp_datach_length_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_dcp_datach_length_total",
           "_base": "target"
         }
       ]
@@ -127,9 +127,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_dcp_dispatch_time_seconds",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_dcp_dispatch_time_seconds",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_dcp_dispatch_time_seconds",
           "_base": "target"
         }
       ]
@@ -139,9 +139,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_filtered_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_filtered_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_filtered_total",
           "_base": "target"
         }
       ]
@@ -151,9 +151,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_set_filtered_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_filtered_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_filtered_total",
           "_base": "target"
         }
       ]
@@ -163,9 +163,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_expiry_filtered_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_filtered_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_filtered_total",
           "_base": "target"
         }
       ]
@@ -175,9 +175,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_deletion_filtered_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_filtered_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_filtered_total",
           "_base": "target"
         }
       ]
@@ -187,9 +187,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_expiry_stripped_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_stripped_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_stripped_total",
           "_base": "target"
         }
       ]
@@ -199,9 +199,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_binary_filtered_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_binary_filtered_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_binary_filtered_total",
           "_base": "target"
         }
       ]
@@ -211,9 +211,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_unable_to_filter_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_unable_to_filter_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_unable_to_filter_total",
           "_base": "target"
         }
       ]
@@ -223,9 +223,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_cloned_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_cloned_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_cloned_total",
           "_base": "target"
         }
       ]
@@ -235,9 +235,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_deletion_cloned_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_cloned_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_cloned_total",
           "_base": "target"
         }
       ]
@@ -247,9 +247,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_size_rep_queue_bytes",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_size_rep_queue_bytes",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_size_rep_queue_bytes",
           "_base": "target"
         }
       ]
@@ -259,9 +259,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_pipeline_status",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_pipeline_status",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_pipeline_status",
           "_base": "target"
         }
       ]
@@ -271,9 +271,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_wtavg_meta_latency_seconds",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_wtavg_meta_latency_seconds",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_wtavg_meta_latency_seconds",
           "_base": "target"
         }
       ]
@@ -283,10 +283,10 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_wtavg_docs_latency_seconds",
           "description": "The rolling average amount of time it takes for the source cluster to receive the acknowledgement of a SET_WITH_META response after the Memcached request has been composed to be processed by the XDCR Target Nozzle",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_wtavg_docs_latency_seconds",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_wtavg_docs_latency_seconds",
           "_base": "target"
         }
       ]
@@ -296,9 +296,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_resp_wait_time_seconds",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_resp_wait_time_seconds",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_resp_wait_time_seconds",
           "_base": "target"
         }
       ]
@@ -308,9 +308,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_written_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_written_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_written_total",
           "_base": "target"
         }
       ]
@@ -320,9 +320,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(xdcr_docs_written_total[5m])",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_written_rate",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_written_rate",
           "_base": "target"
         }
       ]
@@ -332,9 +332,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_data_replicated_bytes",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_data_replicated_bytes",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_data_replicated_bytes",
           "_base": "target"
         }
       ]
@@ -344,9 +344,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(xdcr_data_replicated_bytes[5m])",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_data_replicated_bytes_rate",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_data_replicated_bytes_rate",
           "_base": "target"
         }
       ]
@@ -356,9 +356,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_opt_repd_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_opt_repd_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_opt_repd_total",
           "_base": "target"
         }
       ]
@@ -368,9 +368,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "irate(xdcr_docs_opt_repd_total[5m])",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_opt_repd_rate",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_opt_repd_rate",
           "_base": "target"
         }
       ]
@@ -380,9 +380,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_failed_cr_source_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_failed_cr_source_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_failed_cr_source_total",
           "_base": "target"
         }
       ]
@@ -392,9 +392,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_expiry_failed_cr_source_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_failed_cr_source_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_failed_cr_source_total",
           "_base": "target"
         }
       ]
@@ -404,9 +404,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_deletion_failed_cr_source_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_failed_cr_source_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_failed_cr_source_total",
           "_base": "target"
         }
       ]
@@ -416,9 +416,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_set_failed_cr_source_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_failed_cr_source_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_failed_cr_source_total",
           "_base": "target"
         }
       ]
@@ -428,9 +428,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_failed_cr_target_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_failed_cr_target_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_failed_cr_target_total",
           "_base": "target"
         }
       ]
@@ -440,9 +440,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_throttle_latency_seconds",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_throttle_latency_seconds",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_throttle_latency_seconds",
           "_base": "target"
         }
       ]
@@ -452,9 +452,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_throughput_throttle_latency_seconds",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_throughput_throttle_latency_seconds",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_throughput_throttle_latency_seconds",
           "_base": "target"
         }
       ]
@@ -464,9 +464,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_expiry_docs_written_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_docs_written_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_docs_written_total",
           "_base": "target"
         }
       ]
@@ -476,9 +476,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_expiry_failed_cr_target_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_failed_cr_target_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_expiry_failed_cr_target_total",
           "_base": "target"
         }
       ]
@@ -488,9 +488,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_deletion_docs_written_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_docs_written_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_docs_written_total",
           "_base": "target"
         }
       ]
@@ -500,9 +500,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_deletion_failed_cr_target_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_failed_cr_target_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_deletion_failed_cr_target_total",
           "_base": "target"
         }
       ]
@@ -512,9 +512,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_set_docs_written_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_docs_written_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_docs_written_total",
           "_base": "target"
         }
       ]
@@ -524,9 +524,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_set_failed_cr_target_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_failed_cr_target_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_set_failed_cr_target_total",
           "_base": "target"
         }
       ]
@@ -536,9 +536,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_docs_checked_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_checked_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_docs_checked_total",
           "_base": "target"
         }
       ]
@@ -548,9 +548,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_num_checkpoints_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_num_checkpoints_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_num_checkpoints_total",
           "_base": "target"
         }
       ]
@@ -560,9 +560,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_time_committing_seconds",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_time_committing_seconds",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_time_committing_seconds",
           "_base": "target"
         }
       ]
@@ -572,9 +572,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_data_replicated_uncompress_bytes",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_data_replicated_uncompress_bytes",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_data_replicated_uncompress_bytes",
           "_base": "target"
         }
       ]
@@ -584,9 +584,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_target_eaccess_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_target_eaccess_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_target_eaccess_total",
           "_base": "target"
         }
       ]
@@ -596,9 +596,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_target_tmpfail_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_target_tmpfail_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_target_tmpfail_total",
           "_base": "target"
         }
       ]
@@ -608,9 +608,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_num_failedckpts_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_num_failedckpts_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_num_failedckpts_total",
           "_base": "target"
         }
       ]
@@ -620,9 +620,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_datapool_failed_gets_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_datapool_failed_gets_total",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}}/{{sourceBucketName}}/{{targetBucketName}} {{pipelineType}} xdcr_datapool_failed_gets_total",
           "_base": "target"
         }
       ]
@@ -632,15 +632,15 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_size{proc=\"goxdcr\"}",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         },
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_resident{proc=\"goxdcr\"}",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         }
       ],
@@ -658,9 +658,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sum by (status) (xdcr_pipeline_status{status=\"Running\"})",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}} number of running replications}",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}} number of running replications}",
           "_base": "target"
         }
       ]
@@ -670,9 +670,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "xdcr_number_of_replications_total",
-          "legendFormat": "{data-source-name} {{targetClusterUUID}} number of total replications per remote cluster}",
+          "legendFormat": "{data-source:name} {{targetClusterUUID}} number of total replications per remote cluster}",
           "_base": "target"
         }
       ]
@@ -683,9 +683,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "count(xdcr_number_of_replications_total < xdcr_number_of_replications_total offset 1m)",
-          "legendFormat": "{data-source-name} Replication count decreased in the past minute",
+          "legendFormat": "{data-source:name} Replication count decreased in the past minute",
           "_base": "target"
         }
       ]
@@ -695,9 +695,9 @@
       "_base": "panel",
       "_targets": [
         {
-          "datasource": "{data-source-name}",
+          "datasource": "{data-source:name}",
           "expr": "sysproc_mem_resident{proc=\"goxdcr\"} / ignoring(status, category, instance, job, name, proc) (sum by (status) (xdcr_pipeline_status{status=\"Running\"})) ",
-          "legendFormat": "{data-source-name} {{name}} {{proc}}",
+          "legendFormat": "{data-source:name} {{name}} {{proc}}",
           "_base": "target"
         }
       ],

--- a/promtimer/dashboard.py
+++ b/promtimer/dashboard.py
@@ -138,10 +138,10 @@ def maybe_substitute_templating_variables(
             for idx, param_values in enumerate(template_params):
                 param = param_values[0]
                 pname = param.name()
-                if (item['type'] == 'datasource') and \
-                        (pname == 'data-source' or
-                         pname == 'data-source-name') or \
-                        (pname == 'bucket' and item['type'] == 'custom'):
+                should_substitute = \
+                    (item['type'] == 'datasource' and pname == 'data-source') or \
+                    (item['type'] == 'custom' and pname == 'bucket' and item['name'] == 'bucket')
+                if should_substitute:
                     value = param.make_single_valued_value(f'${variable}')
                     template_params[idx] = (param, [value])
     return template_params

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -115,7 +115,6 @@ def make_dashboards(stats_sources,
     template_params = \
         [(templating.Parameter('data-source', ['name', 'uid']),
             [{'name': s.short_name(), 'uid': s.uid()} for s in stats_sources]),
-         (templating.Parameter('data-source-name'), data_source_names),
          (templating.Parameter('bucket'), buckets if buckets else [])]
     meta_file_names = glob.glob(path.join(util.get_root_dir(), 'dashboards', '*.json'))
     for meta_file_name in meta_file_names:


### PR DESCRIPTION
And replace with `data-source:name`.

In this previous commit:
* d05d9a3: Add support for multi-valued template parameters

Support for the new `data-source` template parameter with two attributes `name` and `uid` was added. This patch completes the work started in that patch with the removal of `data-source-name` as an indepentent template parameter, replacing it with the `name` attribute of `data-source`.

The replacement in dashboard JSON files is simple: `data-source-name` is replaced with `data-source:name`. `data-source-name` is now no longer a valid template parameter to use in dashboards.