### PR TITLE
Add events processed to contbk dashboard

### DIFF
--- a/dashboards/contbk-nodebucket.json
+++ b/dashboards/contbk-nodebucket.json
@@ -51,6 +51,18 @@
       ]
     },
     {
+      "title": "$bucket: Events processed",
+      "_base": "panel",
+      "_targets": [
+        {
+          "datasource": "{data-source:name}",
+          "expr": "contbk_events_processed{bucket=\"$bucket\"}",
+          "legendFormat": "__auto",
+          "_base": "target"
+        }
+      ]
+    },
+    {
       "title": "$bucket: Backup throughput",
       "_base": "panel",
       "fieldConfig": {


### PR DESCRIPTION
Adds `contbk_events_processed` to the continuous backup dashboard. This metric tracks continuous backup start/stop/settings updated events, as well as filesystem events (e.g. new generation on disk).