### PR TITLE
Enhancements for magma dashboard

### DIFF
--- a/dashboards/magma-node.json
+++ b/dashboards/magma-node.json
@@ -241,30 +241,26 @@
         },
         {
             "_base": "panel",
-            "title": "Data block size uncompressed",
+            "title": "Compression",
             "gridPos": {
                 "h": 9
             },
-            "_targets": [
-                {
-                    "datasource": "{data-source:name}",
-                    "expr": "sum by (bucket) (kv_ep_magma_data_blocks_uncompressed_size)",
-                    "legendFormat": "{{bucket}}",
-                    "_base": "target"
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "percent"
                 }
-            ]
-        },
-        {
-            "_base": "panel",
-            "title": "Data block size compressed",
-            "gridPos": {
-                "h": 9
             },
             "_targets": [
                 {
                     "datasource": "{data-source:name}",
-                    "expr": "sum by (bucket) (kv_ep_magma_data_blocks_compressed_size)",
-                    "legendFormat": "{{bucket}}",
+                    "expr": "avg by (bucket) (kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio*100)",
+                    "legendFormat": "{{bucket}} block compression savings %",
+                    "_base": "target"
+                },
+                {
+                    "datasource": "{data-source:name}",
+                    "expr": "(1 - ((sum by (bucket) (kv_ep_total_compressed_value_size_bytes) / (sum by (bucket) (kv_ep_total_decompressed_value_size_bytes) > 0)) or (sum by (bucket) (kv_ep_total_compressed_value_size_bytes) * 0 + 1)) * (sum by (bucket) (kv_ep_magma_data_blocks_compressed_size) / sum by (bucket) (kv_ep_magma_data_blocks_uncompressed_size))) * 100",
+                    "legendFormat": "{{bucket}} total compression savings %",
                     "_base": "target"
                 }
             ]

--- a/dashboards/magma-node.json
+++ b/dashboards/magma-node.json
@@ -271,11 +271,20 @@
             "gridPos": {
                 "h": 9
             },
+            "_reference_lines": [
+                {"match_regex": ".*threshold$"}
+            ],
             "_targets": [
                 {
                     "datasource": "{data-source:name}",
                     "expr": "sum by (bucket) (kv_ep_magma_fragmentation_ratio*100)",
                     "legendFormat": "{{bucket}}",
+                    "_base": "target"
+                },
+                {
+                    "datasource": "{data-source:name}",
+                    "expr": "max by (bucket) (kv_ep_magma_fragmentation_percentage) or max by (bucket) (kv_ep_magma_fragmentation_ratio * 0 + 50)",
+                    "legendFormat": "{{bucket}} threshold",
                     "_base": "target"
                 }
             ]

--- a/dashboards/magma-node.json
+++ b/dashboards/magma-node.json
@@ -83,17 +83,26 @@
             "_base": "panel",
             "title": "Thread pool CPU",
             "gridPos": {
-              "h": 9
+                "h": 9
             },
+            "_reference_lines": [
+                {"match": "cpus available"}
+            ],
             "_targets": [
-              {
-                "datasource": "{data-source:name}",
-                "expr": "sum by (thread_pool) (rate(kv_thread_cpu_usage_seconds[6m]))",
-                "legendFormat": "{{label_name}}",
-                "_base": "target"
-              }
+                {
+                    "datasource": "{data-source:name}",
+                    "expr": "sum by (thread_pool) (rate(kv_thread_cpu_usage_seconds[6m]))",
+                    "legendFormat": "{{thread_pool}}",
+                    "_base": "target"
+                },
+                {
+                    "datasource": "{data-source:name}",
+                    "expr": "sys_cpu_cores_available",
+                    "legendFormat": "cpus available",
+                    "_base": "target"
+                }
             ]
-          },
+        },
           {
             "_base": "panel",
             "title": "Disk IO",

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -1220,7 +1220,8 @@
         "defaults": {
           "custom": {
             "fillOpacity": 5
-          }
+          },
+          "unit": "percent"
         }
       },
       "gridPos": {
@@ -1229,30 +1230,22 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"}",
+          "expr": "kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio{bucket=\"$bucket\"}*100",
           "hide": false,
-          "legendFormat": "uncompressed",
+          "legendFormat": "block compression savings %",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"}",
+          "expr": "(1 - ((kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"} / ignoring(name) (kv_ep_total_decompressed_value_size_bytes{bucket=\"$bucket\"} > 0)) or (kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"} * 0 + 1)) * ignoring(name) (kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"} / ignoring(name) kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"})) * 100",
           "hide": false,
-          "legendFormat": "compressed",
+          "legendFormat": "total compression savings %",
           "range": true,
           "refId": "B"
-        },
-        {
-          "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio{bucket=\"$bucket\"}*100",
-          "hide": false,
-          "legendFormat": "space reduction %",
-          "range": true,
-          "refId": "C"
         }
       ],
-      "title": "Data block compression"
+      "title": "Compression"
     },
     {
       "_base": "panel",

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -642,7 +642,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(kv_magma_write_bytes_{for=\"keyindex\", bucket=\"$bucket\"}[1m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"keyindex\", bucket=\"$bucket\"}[1m])",
           "interval": "",
           "legendFormat": "keyindex",
           "range": true,
@@ -736,7 +736,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "kv_magma_write_bytes_{for=\"keyindex\", bucket=\"$bucket\"}",
+          "expr": "kv_magma_write_bytes_bytes{for=\"keyindex\", bucket=\"$bucket\"}",
           "interval": "",
           "legendFormat": "keyindex",
           "range": true,

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -34,6 +34,27 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "hide": 0,
+        "label": "Write-amp interval",
+        "name": "writeamp_interval",
+        "type": "custom",
+        "query": "5m,15m,30m,1h,2h,6h,12h,1d",
+        "options": [
+          {"selected": false, "text": "5m",  "value": "5m"},
+          {"selected": false, "text": "15m", "value": "15m"},
+          {"selected": false, "text": "30m", "value": "30m"},
+          {"selected": true,  "text": "1h",  "value": "1h"},
+          {"selected": false, "text": "2h",  "value": "2h"},
+          {"selected": false, "text": "6h",  "value": "6h"},
+          {"selected": false, "text": "12h", "value": "12h"},
+          {"selected": false, "text": "1d",  "value": "1d"}
+        ],
+        "current": {"selected": true, "text": "1h", "value": "1h"},
+        "includeAll": false,
+        "multi": false,
+        "skipUrlSync": false
       }
     ]
   },
@@ -1382,7 +1403,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "overall",
           "range": true,
@@ -1390,7 +1411,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "keyindex",
           "range": true,
@@ -1398,7 +1419,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "seqindex",
           "range": true,
@@ -1406,7 +1427,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "seqindex delta",
           "range": true,
@@ -1414,7 +1435,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "(avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m]))-avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "(avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval]))-avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval])))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "seqindex data",
           "range": true,
@@ -1440,7 +1461,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1448,7 +1469,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"keyindex\", bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"keyindex\", bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,
@@ -1493,7 +1514,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1501,7 +1522,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\", bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\", bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,
@@ -1546,7 +1567,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "delta write bytes",
           "range": true,
@@ -1554,7 +1575,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "delta bytes incoming",
           "range": true,
@@ -1562,7 +1583,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1570,7 +1591,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,
@@ -1647,7 +1668,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1655,7 +1676,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -1452,7 +1452,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {
@@ -1505,7 +1505,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {
@@ -1558,7 +1558,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {
@@ -1659,7 +1659,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -1256,6 +1256,9 @@
           }
         }
       },
+      "_reference_lines": [
+        {"match": "fragmentation threshold %"}
+      ],
       "datasource": "${node}",
       "gridPos": {
         "h": 9
@@ -1270,6 +1273,16 @@
           "legendFormat": "fragmentation%",
           "range": true,
           "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "max(kv_ep_magma_fragmentation_percentage{bucket=\"$bucket\"}) or on() vector(50)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "fragmentation threshold %",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "Fragmentation %"

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -310,6 +310,9 @@
           }
         }
       },
+      "_reference_lines": [
+        {"match": "cpus available"}
+      ],
       "gridPos": {
         "h": 9
       },
@@ -320,8 +323,17 @@
           "format": "time_series",
           "instant": false,
           "interval": "",
-          "legendFormat": "{{label_name}}",
+          "legendFormat": "{{thread_pool}}",
           "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sys_cpu_cores_available",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "cpus available",
+          "refId": "B"
         }
       ]
     },

--- a/promtimer/dashboard.py
+++ b/promtimer/dashboard.py
@@ -15,6 +15,7 @@
 #
 
 from os import path
+import copy
 import json
 import logging
 from typing import Any
@@ -102,10 +103,37 @@ def add_targets_to_panel(panel, targets):
         panel['targets'].append(target)
 
 
+REFERENCE_LINE_PROPERTIES = [
+    {'id': 'custom.lineWidth', 'value': 1},
+    {'id': 'custom.fillOpacity', 'value': 0},
+    {'id': 'custom.lineStyle', 'value': {'fill': 'dash', 'dash': [8, 4]}},
+    {'id': 'color', 'value': {'mode': 'fixed', 'fixedColor': 'rgba(200,200,200,0.6)'}},
+]
+
+
+def _reference_line_override(entry):
+    if 'match_regex' in entry:
+        # Grafana's byRegexp option is a slash-wrapped regex.
+        pattern = entry['match_regex'].strip('/')
+        matcher = {'id': 'byRegexp', 'options': f'/{pattern}/'}
+    else:
+        matcher = {'id': 'byName', 'options': entry['match']}
+    return {'matcher': matcher,
+            'properties': copy.deepcopy(REFERENCE_LINE_PROPERTIES)}
+
+
+def add_reference_lines(panel, entries):
+    overrides = panel.setdefault('fieldConfig', {}).setdefault('overrides', [])
+    for entry in entries:
+        overrides.append(_reference_line_override(entry))
+
+
 def make_and_add_targets(panel, panel_meta, template_params):
     if '_targets' in panel_meta:
         targets = make_targets(panel_meta['_targets'], template_params)
         add_targets_to_panel(panel, targets)
+    if '_reference_lines' in panel_meta:
+        add_reference_lines(panel, panel_meta['_reference_lines'])
 
 
 def make_panels(panel_metas: list[dict[str, Any]],

--- a/promtimer/test.py
+++ b/promtimer/test.py
@@ -199,5 +199,47 @@ class TestDashboard(unittest.TestCase):
                          "Should have the correct parameter values")
 
 
+class TestReferenceLines(unittest.TestCase):
+
+    def test_byname_matcher(self):
+        ov = dashboard._reference_line_override({'match': 'cpus available'})
+        self.assertEqual(ov['matcher'],
+                         {'id': 'byName', 'options': 'cpus available'})
+
+    def test_byregexp_matcher_normalizes_to_single_wrap(self):
+        for pattern in ('.*threshold$', '/.*threshold$/', '/.*threshold$',
+                        '.*threshold$/', '//.*threshold$//'):
+            with self.subTest(pattern=pattern):
+                ov = dashboard._reference_line_override({'match_regex': pattern})
+                self.assertEqual(ov['matcher'],
+                                 {'id': 'byRegexp',
+                                  'options': '/.*threshold$/'})
+
+    def test_properties_are_isolated_per_override(self):
+        ov1 = dashboard._reference_line_override({'match': 'a'})
+        ov1['properties'][0]['value'] = 999
+        ov2 = dashboard._reference_line_override({'match': 'b'})
+        self.assertEqual(dashboard.REFERENCE_LINE_PROPERTIES[0]['value'], 1)
+        self.assertEqual(ov2['properties'][0]['value'], 1)
+
+    def test_add_reference_lines_appends_without_clobbering(self):
+        panel = {'fieldConfig': {'defaults': {'unit': 'bytes'},
+                                 'overrides': [{'existing': True}]}}
+        dashboard.add_reference_lines(panel, [{'match': 'a'}, {'match_regex': '.*b'}])
+        overrides = panel['fieldConfig']['overrides']
+        self.assertEqual(panel['fieldConfig']['defaults'], {'unit': 'bytes'})
+        self.assertEqual(len(overrides), 3)
+        self.assertEqual(overrides[0], {'existing': True})
+        self.assertEqual(overrides[1]['matcher'],
+                         {'id': 'byName', 'options': 'a'})
+        self.assertEqual(overrides[2]['matcher'],
+                         {'id': 'byRegexp', 'options': '/.*b/'})
+
+    def test_add_reference_lines_creates_fieldconfig_on_empty_panel(self):
+        panel = {}
+        dashboard.add_reference_lines(panel, [{'match': 'x'}])
+        self.assertEqual(len(panel['fieldConfig']['overrides']), 1)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
This pulls request consists of the following changes:  
  1. Rewrote Compression panel to show block and total (block + per-doc Snappy) savings %.
  2. Added ceiling lines for fragmentation threshold and CPU cores available.
  3. Added Write-amp interval dropdown to tune the rate window live.
  5. Fixed kv_magma_write_bytes_ metric name typo