### PR TITLE
Magma dashboard fixes

### DIFF
--- a/dashboards/magma-node.json
+++ b/dashboards/magma-node.json
@@ -241,30 +241,26 @@
         },
         {
             "_base": "panel",
-            "title": "Data block size uncompressed",
+            "title": "Compression",
             "gridPos": {
                 "h": 9
             },
-            "_targets": [
-                {
-                    "datasource": "{data-source:name}",
-                    "expr": "sum by (bucket) (kv_ep_magma_data_blocks_uncompressed_size)",
-                    "legendFormat": "{{bucket}}",
-                    "_base": "target"
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "percent"
                 }
-            ]
-        },
-        {
-            "_base": "panel",
-            "title": "Data block size compressed",
-            "gridPos": {
-                "h": 9
             },
             "_targets": [
                 {
                     "datasource": "{data-source:name}",
-                    "expr": "sum by (bucket) (kv_ep_magma_data_blocks_compressed_size)",
-                    "legendFormat": "{{bucket}}",
+                    "expr": "avg by (bucket) (kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio*100)",
+                    "legendFormat": "{{bucket}} block compression savings %",
+                    "_base": "target"
+                },
+                {
+                    "datasource": "{data-source:name}",
+                    "expr": "(1 - ((sum by (bucket) (kv_ep_total_compressed_value_size_bytes) / (sum by (bucket) (kv_ep_total_decompressed_value_size_bytes) > 0)) or (sum by (bucket) (kv_ep_total_compressed_value_size_bytes) * 0 + 1)) * (sum by (bucket) (kv_ep_magma_data_blocks_compressed_size) / sum by (bucket) (kv_ep_magma_data_blocks_uncompressed_size))) * 100",
+                    "legendFormat": "{{bucket}} total compression savings %",
                     "_base": "target"
                 }
             ]

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -630,7 +630,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(kv_magma_write_bytes_{for=\"keyindex\", bucket=\"$bucket\"}[1m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"keyindex\", bucket=\"$bucket\"}[1m])",
           "interval": "",
           "legendFormat": "keyindex",
           "range": true,
@@ -724,7 +724,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "kv_magma_write_bytes_{for=\"keyindex\", bucket=\"$bucket\"}",
+          "expr": "kv_magma_write_bytes_bytes{for=\"keyindex\", bucket=\"$bucket\"}",
           "interval": "",
           "legendFormat": "keyindex",
           "range": true,

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -34,6 +34,27 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "hide": 0,
+        "label": "Write-amp interval",
+        "name": "writeamp_interval",
+        "type": "custom",
+        "query": "5m,15m,30m,1h,2h,6h,12h,1d",
+        "options": [
+          {"selected": false, "text": "5m",  "value": "5m"},
+          {"selected": false, "text": "15m", "value": "15m"},
+          {"selected": false, "text": "30m", "value": "30m"},
+          {"selected": true,  "text": "1h",  "value": "1h"},
+          {"selected": false, "text": "2h",  "value": "2h"},
+          {"selected": false, "text": "6h",  "value": "6h"},
+          {"selected": false, "text": "12h", "value": "12h"},
+          {"selected": false, "text": "1d",  "value": "1d"}
+        ],
+        "current": {"selected": true, "text": "1h", "value": "1h"},
+        "includeAll": false,
+        "multi": false,
+        "skipUrlSync": false
       }
     ]
   },
@@ -1357,7 +1378,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_ep_magma_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "overall",
           "range": true,
@@ -1365,7 +1386,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "keyindex",
           "range": true,
@@ -1373,7 +1394,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "seqindex",
           "range": true,
@@ -1381,7 +1402,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval]))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "seqindex delta",
           "range": true,
@@ -1389,7 +1410,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "(avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m]))-avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[15m]))",
+          "expr": "(avg by (job)(rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval]))-avg by (job)(rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval])))/avg by (job)(rate(kv_ep_magma_bytes_incoming_bytes{bucket=\"$bucket\"}[$writeamp_interval]))",
           "hide": false,
           "legendFormat": "seqindex data",
           "range": true,
@@ -1415,7 +1436,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"keyindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1423,7 +1444,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"keyindex\", bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"keyindex\", bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,
@@ -1468,7 +1489,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1476,7 +1497,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\", bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\", bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,
@@ -1521,7 +1542,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "delta write bytes",
           "range": true,
@@ -1529,7 +1550,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "delta bytes incoming",
           "range": true,
@@ -1537,7 +1558,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_write_bytes_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1545,7 +1566,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\",bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_magma_bytes_incoming_bytes{for=\"seqindex\",bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,
@@ -1622,7 +1643,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_write_bytes_bytes{bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "write bytes",
           "range": true,
@@ -1630,7 +1651,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[15m])",
+          "expr": "rate(kv_ep_magma_seqindex_delta_bytes_incoming_bytes{ bucket=\"$bucket\"}[$writeamp_interval])",
           "hide": false,
           "legendFormat": "bytes incoming",
           "range": true,

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -1220,7 +1220,8 @@
         "defaults": {
           "custom": {
             "fillOpacity": 5
-          }
+          },
+          "unit": "percent"
         }
       },
       "gridPos": {
@@ -1229,30 +1230,22 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"}",
+          "expr": "kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio{bucket=\"$bucket\"}*100",
           "hide": false,
-          "legendFormat": "uncompressed",
+          "legendFormat": "block compression savings %",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"}",
+          "expr": "(1 - ((kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"} / ignoring(name) (kv_ep_total_decompressed_value_size_bytes{bucket=\"$bucket\"} > 0)) or (kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"} * 0 + 1)) * ignoring(name) (kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"} / ignoring(name) kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"})) * 100",
           "hide": false,
-          "legendFormat": "compressed",
+          "legendFormat": "total compression savings %",
           "range": true,
           "refId": "B"
-        },
-        {
-          "editorMode": "code",
-          "expr": "kv_ep_magma_data_blocks_space_reduction_estimate_pct_ratio{bucket=\"$bucket\"}*100",
-          "hide": false,
-          "legendFormat": "space reduction %",
-          "range": true,
-          "refId": "C"
         }
       ],
-      "title": "Data block compression"
+      "title": "Compression"
     },
     {
       "_base": "panel",

--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -1406,7 +1406,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {
@@ -1459,7 +1459,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {
@@ -1512,7 +1512,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {
@@ -1613,7 +1613,7 @@
           "custom": {
             "fillOpacity": 5
           },
-          "unit": "binBps"
+          "unit": "none"
         }
       },
       "gridPos": {


### PR DESCRIPTION
## Magma dashboard fixes

The full request has the following changes:

1. **Compression panel** — replace raw-bytes panels with block-savings % and total-savings % (block + per-doc Snappy combined via `1 − (D_c/D_d) × (B_c/B_u)`). Uses `ignoring(name)` + `D_d > 0` guard so it degrades cleanly when per-doc compression is off.
2. **Metric typo** — `kv_magma_write_bytes_{...}` → `kv_magma_write_bytes_bytes{...}` on keyindex write-bytes panels.
3. **Unit fix** — write-amp ratio panels changed from `binBps` → `none` (they render a unitless ratio after a `calculateField` transformation with `replaceFields: true`).
4. **Write-amp interval dropdown** — new `writeamp_interval` template variable (5m–1d, default 1h) replacing hardcoded `[15m]` in the write-amp panels.