### PR TITLE
Fix "total compression savings" query on Magma - Node & Bucket dashboard

### DIFF
--- a/dashboards/magma-nodebucket.json
+++ b/dashboards/magma-nodebucket.json
@@ -1259,7 +1259,7 @@
         },
         {
           "editorMode": "code",
-          "expr": "(1 - ((kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"} / ignoring(name) (kv_ep_total_decompressed_value_size_bytes{bucket=\"$bucket\"} > 0)) or (kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"} * 0 + 1)) * ignoring(name) (kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"} / ignoring(name) kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"})) * 100",
+          "expr": "(1 - ((sum by (bucket) (kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"}) / (sum by (bucket) (kv_ep_total_decompressed_value_size_bytes{bucket=\"$bucket\"}) > 0)) or (sum by (bucket) (kv_ep_total_compressed_value_size_bytes{bucket=\"$bucket\"}) * 0 + 1)) * (sum by (bucket) (kv_ep_magma_data_blocks_compressed_size{bucket=\"$bucket\"}) / sum by (bucket) (kv_ep_magma_data_blocks_uncompressed_size{bucket=\"$bucket\"}))) * 100",
           "hide": false,
           "legendFormat": "total compression savings %",
           "range": true,


### PR DESCRIPTION
The `total compression savings %` series silently dropped on any bucket with non-zero per-doc Snappy counters — Prometheus errored with `multiple matches for labels: many-to-one matching must be explicit`.

Root cause: the old expression used `ignoring(name)` + an `or` fallback whose operands ended up with mismatched label sets, so Prometheus kept two series where one was expected.

Fix: use `sum by (bucket)` on every metric (matches the style in `magma-node.json`).

Verified on `compressionMode=active` and `compressionMode=off`.