### PR TITLE
Add 8.1.0 FTS metrics to search dashboard

### DIFF
--- a/dashboards/search-dashboard.json
+++ b/dashboards/search-dashboard.json
@@ -491,6 +491,114 @@
             ]
           },
           {
+            "title": "fts_num_goroutines",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_num_goroutines",
+                "legendFormat": "{data-source:name} fts_num_goroutines",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_num_cgocalls",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_num_cgocalls",
+                "legendFormat": "{data-source:name} fts_num_cgocalls",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_heap_alloc",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_heap_alloc",
+                "legendFormat": "{data-source:name} fts_heap_alloc",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_heap_idle",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_heap_idle",
+                "legendFormat": "{data-source:name} fts_heap_idle",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_heap_inuse",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_heap_inuse",
+                "legendFormat": "{data-source:name} fts_heap_inuse",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_heap_released",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_heap_released",
+                "legendFormat": "{data-source:name} fts_heap_released",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_mallocs",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_mallocs",
+                "legendFormat": "{data-source:name} fts_mallocs",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_frees",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_frees",
+                "legendFormat": "{data-source:name} fts_frees",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_total_scan_plus_queries_kv_errors",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_total_scan_plus_queries_kv_errors",
+                "legendFormat": "{data-source:name} fts_total_scan_plus_queries_kv_errors",
+                "_base": "target"
+              }
+            ]
+          },
+          {
             "title": "fts_total_vector_indexes_in_gpu",
             "_base": "panel",
             "_targets": [

--- a/dashboards/search-dashboard.json
+++ b/dashboards/search-dashboard.json
@@ -489,6 +489,30 @@
                 "_base": "target"
               }
             ]
+          },
+          {
+            "title": "fts_total_vector_indexes_in_gpu",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_total_vector_indexes_in_gpu",
+                "legendFormat": "{data-source:name} fts_total_vector_indexes_in_gpu",
+                "_base": "target"
+              }
+            ]
+          },
+          {
+            "title": "fts_total_vector_indexes_in_cpu",
+            "_base": "panel",
+            "_targets": [
+              {
+                "datasource": "{data-source:name}",
+                "expr": "fts_total_vector_indexes_in_cpu",
+                "legendFormat": "{data-source:name} fts_total_vector_indexes_in_cpu",
+                "_base": "target"
+              }
+            ]
           }
     ]
   }


### PR DESCRIPTION
Adds panels to the search dashboard for the new FTS metrics introduced in 8.1.0 (per `cbft/etc/metrics_metadata.json`):

Go runtime / heap:
- `fts_num_goroutines` - current number of goroutines running in the FTS process
- `fts_num_cgocalls` - total number of CGo calls made by the FTS process since startup
- `fts_heap_alloc` - bytes of allocated heap objects currently in use
- `fts_heap_idle` - bytes in idle (unused) heap spans
- `fts_heap_inuse` - bytes in non-idle heap spans
- `fts_heap_released` - bytes of physical memory returned to the OS
- `fts_mallocs` - cumulative count of heap objects allocated
- `fts_frees` - cumulative count of heap objects freed

Query errors:
- `fts_total_scan_plus_queries_kv_errors` - total number of KV errors encountered during scan plus queries

Vector index placement (GPU / CPU):
- `fts_total_vector_indexes_in_gpu` - total number of segmented vector indexes currently loaded in GPU memory
- `fts_total_vector_indexes_in_cpu` - total number of segmented vector indexes currently loaded in CPU memory