### PR TITLE
Add objstore stats to cbbackupmgr/contbk dashboards

### DIFF
--- a/dashboards/cbbackupmgr-stats.json
+++ b/dashboards/cbbackupmgr-stats.json
@@ -536,6 +536,102 @@
           }
         ],
         "title": "Dropout"
+      },
+      {
+        "_base": "row",
+        "title": "Objstore"
+      },
+      {
+        "_base": "panel",
+        "gridPos": {
+          "h": 8
+        },
+        "_targets": [
+          {
+            "_base": "target",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source:uid}"
+            },
+            "editorMode": "builder",
+            "expr": "objstore_request_count{status=\"succeeded\"}",
+            "legendFormat": "{{method}}"
+          }
+        ],
+        "title": "Successful requests"
+      },
+      {
+        "_base": "panel",
+        "gridPos": {
+          "h": 8
+        },
+        "_targets": [
+          {
+            "_base": "target",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source:uid}"
+            },
+            "editorMode": "builder",
+            "expr": "objstore_request_count{status=\"failed\"}",
+            "legendFormat": "{{method}}"
+          }
+        ],
+        "title": "Failed requests"
+      },
+      {
+        "_base": "panel",
+        "gridPos": {
+          "h": 8
+        },
+        "_targets": [
+          {
+            "_base": "target",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source:uid}"
+            },
+            "editorMode": "builder",
+            "expr": "rate(objstore_request_bytes{status=\"succeeded\"}[1m])",
+            "legendFormat": "{{method}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "fillOpacity": 1
+            },
+            "unit": "binBps"
+          }
+        },
+        "title": "Throughput"
+      },
+      {
+        "_base": "panel",
+        "gridPos": {
+          "h": 8
+        },
+        "_targets": [
+          {
+            "_base": "target",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{data-source:uid}"
+            },
+            "editorMode": "builder",
+            "expr": "objstore_request_elapsed_ms{status=\"succeeded\"}",
+            "legendFormat": "{{method}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "fillOpacity": 1
+            },
+            "unit": "milliseconds"
+          }
+        },
+        "title": "Time"
       }
     ],
     "refresh": false,

--- a/dashboards/contbk-nodebucket.json
+++ b/dashboards/contbk-nodebucket.json
@@ -157,6 +157,102 @@
           "_base": "target"
         }
       ]
+    },
+    {
+      "_base": "row",
+      "title": "Objstore"
+    },
+    {
+      "_base": "panel",
+      "gridPos": {
+        "h": 8
+      },
+      "_targets": [
+        {
+          "_base": "target",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{data-source:uid}"
+          },
+          "editorMode": "builder",
+          "expr": "contbk_objstore_request_count{status=\"succeeded\"}",
+          "legendFormat": "{{request}}"
+        }
+      ],
+      "title": "$bucket: Successful requests"
+    },
+    {
+      "_base": "panel",
+      "gridPos": {
+        "h": 8
+      },
+      "_targets": [
+        {
+          "_base": "target",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{data-source:uid}"
+          },
+          "editorMode": "builder",
+          "expr": "contbk_objstore_request_count{status=\"failed\"}",
+          "legendFormat": "{{request}}"
+        }
+      ],
+      "title": "$bucket: Failed requests"
+    },
+    {
+      "_base": "panel",
+      "gridPos": {
+        "h": 8
+      },
+      "_targets": [
+        {
+          "_base": "target",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{data-source:uid}"
+          },
+          "editorMode": "builder",
+          "expr": "rate(contbk_objstore_request_bytes{status=\"succeeded\"}[1m])",
+          "legendFormat": "{{request}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 1
+          },
+          "unit": "binBps"
+        }
+      },
+      "title": "$bucket: Throughput"
+    },
+    {
+      "_base": "panel",
+      "gridPos": {
+        "h": 8
+      },
+      "_targets": [
+        {
+          "_base": "target",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{data-source:uid}"
+          },
+          "editorMode": "builder",
+          "expr": "contbk_objstore_request_duration{status=\"succeeded\"}",
+          "legendFormat": "{{request}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 1
+          },
+          "unit": "milliseconds"
+        }
+      },
+      "title": "$bucket: Time"
     }
   ]
 }


### PR DESCRIPTION
This adds graphs for cloud storage requests to both cbbackupmgr and continuous backup dashboards. 