### PR TITLE
Retain template variables when following same-time-range dashboard links

### DIFF
--- a/templates/dashboard.json
+++ b/templates/dashboard.json
@@ -7,10 +7,10 @@
     {
       "asDropdown": true,
       "icon": "external link",
-      "includeVars": false,
+      "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "title": "Other Dashboards (same time range)",
+      "title": "Other Dashboards (same time range & variables)",
       "type": "dashboards"
     },
     {


### PR DESCRIPTION
Set includeVars on the "Other Dashboards (same time range)" dropdown so that the selected node (and bucket, where present) carries over to the target dashboard instead of resetting to the default, and rename it to "Other Dashboards (same time range & variables)" to say so. The plain "Other Dashboards" dropdown keeps the existing reset behaviour, so both options remain available.