### PR TITLE
MB-65001: Backfill ns_server.stats.log heartbeat into snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ To browse stats online, all you need is a live cluster to run against.
 For offline browsing of stats, you will additionally need:
 * A Prometheus binary (version 2.20 or later)
 * Some cbcollects
+* (Optional) `promtool`, to additionally parse each cbcollect's
+  `ns_server.stats.log` into heartbeat metrics (Erlang memory breakdown,
+  the meminfo anon/file split, per-process RSS/CPU, and PSI pressure for
+  captures from before 7.2.4) shown on the "NS Server log-derived"
+  dashboard. Without
+  promtool this step is skipped and Promtimer works as before. Note that
+  the `install/bin` directory of a Couchbase Server build contains
+  `prometheus` but not `promtool`; the Prometheus release archives and
+  `brew install prometheus` include both. The log is read straight out of
+  the cbcollect zip when there is one, as couchbase.log and diag.log
+  already are, so cbcollects need no unzipping for this either. The parse happens once per cbcollect (subsequent
+  opens reuse the generated metrics; `--heartbeat=refresh` regenerates
+  them, `--heartbeat=skip` disables).
 * (Optional) Event Logger from [cbmultimanager](https://github.com/couchbaselabs/cbmultimanager)
   if you wish to generate an `events.log` file
 

--- a/dashboards/node-log-derived.json
+++ b/dashboards/node-log-derived.json
@@ -1,0 +1,400 @@
+{
+  "_base": "dashboard",
+  "title": "NS Server log-derived",
+  "annotations": {
+    "list": [
+      {
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": false,
+        "iconColor": "#ffffff",
+        "limit": 500,
+        "matchAny": true,
+        "name": "Topology",
+        "showIn": 0,
+        "tags": [
+          "topology"
+        ],
+        "type": "tags"
+      },
+      {
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": false,
+        "iconColor": "#115fd4",
+        "limit": 500,
+        "matchAny": true,
+        "name": "Buckets",
+        "showIn": 0,
+        "tags": [
+          "buckets"
+        ],
+        "type": "tags"
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "_panels": [
+    {
+      "_base": "text",
+      "gridPos": {
+        "w": 24,
+        "h": 3
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Every panel here is parsed from **ns_server.stats.log** - the ns_doctor heartbeat, roughly one sample a minute - and not scraped by Prometheus. Every series is whole-node: the heartbeat reads /proc and has no cgroup view.\nPrefer the scraped equivalent on **Node Overview** wherever the capture has one; panels name theirs.\nThese panels also cover a shorter span than the scraped stats, so they can start partway into the time range where the others do not."
+      }
+    },
+    {
+      "title": "CPU",
+      "_base": "row"
+    },
+    {
+      "title": "CPU utilization / steal (heartbeat)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_cpu_utilization_percent",
+          "legendFormat": "utilization",
+          "_base": "target",
+          "interval": "1m"
+        },
+        {
+          "expr": "heartbeat_cpu_stolen_percent",
+          "legendFormat": "stolen",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "description": "Whole-node CPU, from sigar.\n\n- **utilization** - percentage of the node's CPU that was busy\n- **stolen** - percentage of time the hypervisor ran another guest on the vCPU (Linux VMs only)\n\nPrefer sys_cpu_utilization_rate and the CPU attribution panels on Node Overview where the capture has them: scraped, and cgroup-aware."
+    },
+    {
+      "title": "Per-process CPU (heartbeat)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_process_cpu_percent",
+          "legendFormat": "{{proc}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "description": "CPU per process, one series for each process in the heartbeat.\n\nPrefer sysproc_cpu_utilization on Node Overview where the capture has it: the same instrument, at scrape resolution."
+    },
+    {
+      "title": "CPU pressure - share of time stalled, avg60 (host)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_pressure_avg60_percent{resource=\"cpu\"}",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "description": "PSI share of time the node was stalled waiting for CPU, the kernel's 60-second average.\n\n- **some** - share of time at least one task was stalled\n- **full** - share of time every non-idle task was stalled at once; the kernel tracks this per-cgroup only, so the host series reads zero or is absent\n\nPrefer 'CPU pressure - host vs cgroup (share of time stalled, avg10)' on Node Overview where the capture has it: scraped from 7.2.4, at avg10 and scrape resolution, host and cgroup separately. This panel is the only PSI an earlier capture has."
+    },
+    {
+      "title": "CPU pressure - stall time rate (host)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(heartbeat_pressure_stall_microseconds_total{resource=\"cpu\"}[5m])",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s/s"
+        }
+      },
+      "description": "Microseconds of PSI stall per second waiting for CPU, as a rate of the kernel's cumulative counter. Sampled once a minute, so a minute is the finest slice it resolves.\n\n- **some** - time at least one task was stalled\n- **full** - time every non-idle task was stalled at once; the host series reads zero or is absent, as above\n\nPrefer 'CPU pressure - host vs cgroup (share of time stalled, avg10)' on Node Overview where the capture has it: the same counter, scraped from 7.2.4 as sys_pressure_total_stall_time_usec."
+    },
+    {
+      "title": "Memory",
+      "_base": "row"
+    },
+    {
+      "title": "OS memory (memsup)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_os_memory_bytes",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "description": "The node's memory as memsup's get_system_memory_data() reports it. Which tags appear is platform-dependent, and memsup may add tags without notice.\n\n- **total_memory** - the total amount of memory available to the Erlang emulator, allocated and free\n- **system_total_memory** - the amount of memory available to the whole operating system\n- **free_memory** - the amount of free memory available to the Erlang emulator for allocation\n- **available_memory** - the amount of memory available for increased usage if there is an increased memory need; newer Linux kernels only, and where it is absent free + cached + buffered approximates it\n- **cached_memory** - the amount of memory the system uses for cached files read from disk; on Linux, memory marked reclaimable in the kernel slab allocator is added to this too\n- **buffered_memory** - the amount of memory the system uses for temporarily storing raw disk blocks\n- **total_swap** - the total amount of memory the system has available for disk swap\n- **free_swap** - the amount of memory the system has available for disk swap\n- **shared_memory** / **largest_free** - tags memsup can return that its documentation does not describe\n\nPrefer the sys_mem_* panels on Node Overview where the capture has them: scraped, and with the Couchbase cgroup broken out."
+    },
+    {
+      "title": "Per-process resident memory (heartbeat)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_process_resident_memory_bytes",
+          "legendFormat": "{{proc}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "description": "Resident set size per process, one series for each process in the heartbeat. RSS includes shared pages, so the series do not sum to the node's usage.\n\nPrefer sysproc_mem_resident on Node Overview where the capture has it: the same instrument, at scrape resolution."
+    },
+    {
+      "title": "meminfo anon/file LRU split (Linux)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_meminfo_bytes{kind=~\"active_anon|inactive_anon|active_file|inactive_file|dirty|writeback\"}",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "description": "The kernel's reclaim lists, from /proc/meminfo. Linux only.\n\n- **active_anon** / **inactive_anon** - anonymous pages (heaps, stacks), recently used and not; these can be swapped but not dropped\n- **active_file** / **inactive_file** - file-backed page cache; the inactive half is reclaimed first\n- **dirty** - pages modified and not yet written back\n- **writeback** - pages being written back"
+    },
+    {
+      "title": "meminfo reclaim fields (Linux)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_meminfo_bytes{kind=~\"mem_available|slab|sunreclaim|percpu\"}",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "description": "The /proc/meminfo fields describing reclaimable memory. Linux only.\n\n- **mem_available** - the kernel's estimate of what can be allocated without swapping: free memory plus the reclaimable part of the cache\n- **slab** - kernel data structures (inodes, dentries and the rest)\n- **sunreclaim** - the part of slab that cannot be reclaimed\n- **percpu** - per-CPU allocator memory"
+    },
+    {
+      "title": "Erlang memory breakdown (erlang:memory)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_erlang_memory_bytes",
+          "legendFormat": "{{type}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "description": "Memory dynamically allocated by the Erlang emulator, from erlang:memory(). More types may be added in a future release.\n\n- **total** - the total amount of memory currently allocated; the same as the sum of processes and system\n- **processes** - the total amount of memory currently allocated for the Erlang processes\n- **processes_used** - the amount of that currently used by the Erlang processes\n- **system** - memory currently allocated for the emulator that is not directly related to any Erlang process\n- **atom** - memory currently allocated for atoms; part of system\n- **atom_used** - the amount of that currently used\n- **binary** - memory currently allocated for binaries; part of system\n- **code** - memory currently allocated for Erlang code; part of system\n- **ets** - memory currently allocated for ETS tables; part of system\n\nThe series overlap rather than partition the total, so they do not add up: system = atom + binary + code + ets + other system memory, and processes = processes_used + the rest.\n\nThe docs note this accounting is approximate: system is incomplete, that error carries into total, and the amounts are not gathered atomically. total is not meant to equal the emulator's mapped pages - it excludes shared libraries, the emulator's own code and its stacks, while fragmentation and prereservation mean the segments holding it can be much larger."
+    },
+    {
+      "title": "Worst Erlang process memory (memsup)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_erlang_worst_process_memory_bytes",
+          "legendFormat": "{{pid}} {{name}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "description": "The largest single Erlang process on the node by allocated bytes, as memsup's get_memory_data() reports it, labelled with its pid and, where diag.log's process dump names it, its registered name or initial call.\n\nThe largest process is re-picked at every sample, so a series starts and stops as the winner changes.\n\nmemsup returns the result of its latest memory check rather than running a fresh one, so a sample can lag its timestamp by up to the check interval - one minute by default. The value is undefined where memsup is configured not to collect process data (memsup_system_only)."
+    },
+    {
+      "title": "Memory pressure - share of time stalled, avg60 (host)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_pressure_avg60_percent{resource=\"memory\"}",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "description": "PSI share of time the node was stalled waiting on memory reclaim, the kernel's 60-second average.\n\n- **some** - share of time at least one task was stalled\n- **full** - share of time every non-idle task was stalled at once\n\nPrefer 'Memory pressure - host vs cgroup (share of time stalled, avg10)' on Node Overview where the capture has it: scraped from 7.2.4, at avg10 and scrape resolution, host and cgroup separately. This panel is the only PSI an earlier capture has."
+    },
+    {
+      "title": "Memory pressure - stall time rate (host)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(heartbeat_pressure_stall_microseconds_total{resource=\"memory\"}[5m])",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s/s"
+        }
+      },
+      "description": "Microseconds of PSI stall per second waiting on memory reclaim, as a rate of the kernel's cumulative counter. Sampled once a minute, so a minute is the finest slice it resolves.\n\n- **some** - time at least one task was stalled\n- **full** - time every non-idle task was stalled at once\n\nPrefer 'Memory pressure - host vs cgroup (share of time stalled, avg10)' on Node Overview where the capture has it: the same counter, scraped from 7.2.4 as sys_pressure_total_stall_time_usec."
+    },
+    {
+      "title": "Memory allocation stalls (10m increase)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "increase(heartbeat_allocstall_total[10m])",
+          "legendFormat": "allocstalls",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "description": "Direct-reclaim stalls per 10-minute window, from the kernel's allocstall counter: the kernel counts one each time an allocation could not be met from free memory and the allocating task reclaimed memory itself rather than leaving it to kswapd. Linux only."
+    },
+    {
+      "title": "Disk",
+      "_base": "row"
+    },
+    {
+      "title": "IO pressure - share of time stalled, avg60 (host)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_pressure_avg60_percent{resource=\"io\"}",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "description": "PSI share of time the node was stalled waiting on IO, the kernel's 60-second average.\n\n- **some** - share of time at least one task was stalled\n- **full** - share of time every non-idle task was stalled at once\n\nPrefer 'IO pressure - host vs cgroup (share of time stalled, avg10)' on Node Overview where the capture has it: scraped from 7.2.4, at avg10 and scrape resolution, host and cgroup separately. This panel is the only PSI an earlier capture has."
+    },
+    {
+      "title": "IO pressure - stall time rate (host)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "rate(heartbeat_pressure_stall_microseconds_total{resource=\"io\"}[5m])",
+          "legendFormat": "{{kind}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "\u00b5s/s"
+        }
+      },
+      "description": "Microseconds of PSI stall per second waiting on IO, as a rate of the kernel's cumulative counter. Sampled once a minute, so a minute is the finest slice it resolves.\n\n- **some** - time at least one task was stalled\n- **full** - time every non-idle task was stalled at once\n\nPrefer 'IO pressure - host vs cgroup (share of time stalled, avg10)' on Node Overview where the capture has it: the same counter, scraped from 7.2.4 as sys_pressure_total_stall_time_usec."
+    },
+    {
+      "title": "Disk usage by mount (disksup)",
+      "datasource": "{data-source:name}",
+      "_base": "panel",
+      "_targets": [
+        {
+          "expr": "heartbeat_disk_usage_percent",
+          "legendFormat": "{{mount}}",
+          "_base": "target",
+          "interval": "1m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      },
+      "description": "Percentage full per mount, as Erlang's disksup reports it: every mount it checks, tmpfs included. disksup runs on its own timer rather than per heartbeat, so the series step rather than curve. Mount sizes are backfilled too, as heartbeat_disk_capacity_bytes."
+    }
+  ],
+  "description": "Metrics parsed out of ns_server logs, not scraped from Prometheus: every panel comes from the ns_doctor heartbeat in ns_server.stats.log, roughly one sample a minute, mixing OS instruments (meminfo, PSI, sigar) with Erlang-VM instruments (erlang:memory, memsup). Collection gaps are drawn as breaks in the line.\n\nPrefer the scraped stats wherever the capture has them: Node Overview carries most of these instruments at scrape resolution and separates the host from the Couchbase cgroup. The heartbeat reads /proc and has no cgroup view, so every series here is whole-node. Panels name their Node Overview equivalent where there is one.\n\nThe heartbeat also covers a shorter span than the scraped stats, bounded by size rather than time: stats.log keeps 40 MiB per file over 10 rotations, all of which cbcollect concatenates, and each dump covers every node and bucket, so the span narrows as a cluster grows - a couple of days is typical, less on a large one. These panels can therefore start partway into the time range where the others do not.",
+  "tags": [
+    "log-derived",
+    "stats.log",
+    "heartbeat"
+  ]
+}

--- a/promtimer/cbstats.py
+++ b/promtimer/cbstats.py
@@ -27,6 +27,7 @@ import os
 import zoneinfo
 import hashlib
 from os import path
+from collections import namedtuple
 from urllib.parse import urlparse, urlunparse
 from http.client import HTTPException
 from abc import ABC, abstractmethod
@@ -37,6 +38,24 @@ import util
 COUCHBASE_LOG = 'couchbase.log'
 DIAG_LOG = 'diag.log'
 STATS_SNAPSHOT_DIR_NAME = 'stats_snapshot'
+CBCOLLECT_DIR_PREFIX = 'cbcollect_info'
+
+# The name cbcollect_info gives its output: the capturing node, then the
+# capture time. The node is ns_<n>@host on an installed cluster and
+# n_<n>@host under cluster_run. Not anchored at the end, so a name with
+# anything appended still parses.
+CBCOLLECT_DIR_RE = re.compile(
+    CBCOLLECT_DIR_PREFIX + r'_(ns?)_(\d+)@(.*)_(\d+)-(\d+)')
+
+
+class CBCollectDirName(
+        namedtuple('CBCollectDirName', 'prefix index host date time')):
+    """The parts of a cbcollect_info directory name."""
+
+    @property
+    def node(self):
+        """The Erlang node name, as the node calls itself in the logs."""
+        return '{}_{}@{}'.format(self.prefix, self.index, self.host)
 
 
 class Source(ABC):
@@ -287,7 +306,8 @@ class CBCollect(Source):
         """
         if self._zipfile:
             with zipfile.ZipFile(self._zipfile) as z:
-                filename = path.join(self._cbcollect_dir, log_file)
+                filename = CBCollect.zip_member_path(self._cbcollect_dir,
+                                                     log_file)
                 with z.open(filename, 'r') as filestream:
                     filereader = io.TextIOWrapper(filestream, 'utf-8', errors='replace')
                     return fun(filereader)
@@ -317,13 +337,84 @@ class CBCollect(Source):
         return candidate_path.is_dir() and CBCollect.snapshot_dir_exists(candidate_path)
 
     @staticmethod
+    def has_cbcollect_dir_name(name):
+        """
+        Returns whether name is the name cbcollect_info gives its output directory:
+        cbcollect_info_<node>_<timestamp>, which cbcollect_info fixes with no way to
+        override it.
+        :type name: string
+        :rtype: bool
+        """
+        return name.startswith(CBCOLLECT_DIR_PREFIX)
+
+    @staticmethod
+    def find_candidate_zips():
+        """
+        Returns the sorted names of the zip files in the working directory, any of
+        which may be a cbcollect zip. Whether a zip actually holds something usable
+        is up to the caller: Promtimer wants a stats_snapshot in it, the heartbeat
+        backfill wants an ns_server.stats.log.
+        :rtype: list of names of zip files
+        """
+        return sorted(glob.glob('*.zip'))
+
+    @staticmethod
+    def find_candidate_dirs():
+        """
+        Returns the sorted names of the directories in the working directory that
+        are named the way cbcollect_info names its output, whether or not they hold
+        anything Promtimer can use.
+        :rtype: list of names of directories
+        """
+        return [d for d in sorted(glob.glob(CBCOLLECT_DIR_PREFIX + '*'))
+                if path.isdir(d)]
+
+    @staticmethod
+    def find_dir_in_zip(zip_file):
+        """
+        Returns the name of the cbcollect directory inside an open zip, identified
+        by name rather than by content: the caller decides what it needs to find in
+        there. Returns None if the zip holds no such directory.
+        :type zip_file: zipfile.ZipFile
+        :rtype: string or None
+        """
+        dirs = [p for p in zipfile.Path(zip_file).iterdir() if p.is_dir()]
+        for p in dirs:
+            if CBCollect.has_cbcollect_dir_name(p.name):
+                return p.name
+        # Nothing named the way cbcollect_info names it: fall back to the
+        # directory holding a stats_snapshot, which is how this used to be
+        # identified, so a zip whose directory has been renamed still opens.
+        for p in dirs:
+            if CBCollect.snapshot_dir_exists(p):
+                return p.name
+        return None
+
+    @staticmethod
+    def parse_dir_name(cbcollect_dir):
+        """
+        Returns the parts of a cbcollect_info directory's name as a
+        CBCollectDirName, whose .node is the name the capturing node goes by in
+        the logs. Returns None for a directory not named the way cbcollect_info
+        names its output.
+        :type cbcollect_dir: string, a path or a bare directory name. Only the
+                             name itself is looked at, never the working
+                             directory, so '.' doesn't parse: a caller wanting
+                             the directory Promtimer is being run inside passes
+                             an absolute path.
+        :rtype: CBCollectDirName or None
+        """
+        m = CBCOLLECT_DIR_RE.match(path.basename(path.normpath(cbcollect_dir)))
+        return CBCollectDirName(*m.groups()) if m else None
+
+    @staticmethod
     def find_cbcollect_dirs():
-        cbcollects = sorted(glob.glob('cbcollect_info*'))
+        cbcollects = CBCollect.find_candidate_dirs()
         return [f for f in cbcollects if CBCollect.is_cbcollect_dir(pathlib.Path(f))]
 
     @staticmethod
     def get_cbcollect_dirs():
-        zips = sorted(glob.glob('*.zip'))
+        zips = CBCollect.find_candidate_zips()
         dirs = {}
         for z in zips:
             with zipfile.ZipFile(z) as zip_file:
@@ -334,6 +425,19 @@ class CBCollect(Source):
         for cbcollect_dir in cbcollect_dirs:
             result.append((cbcollect_dir, dirs.get(cbcollect_dir)))
         return result
+
+    @staticmethod
+    def zip_member_path(cbcollect_dir, name):
+        """
+        The name of one of a cbcollect's files inside the cbcollect zip. Zip
+        member names always use '/', whatever the platform, so this is
+        deliberately not os.path.join: joining with a backslash builds a name no
+        member has, and reading it raises KeyError.
+        :type cbcollect_dir: string, the cbcollect directory inside the zip
+        :type name: string, a path relative to the cbcollect directory
+        :rtype: string
+        """
+        return '{}/{}'.format(cbcollect_dir, name)
 
     @staticmethod
     def is_stats_snapshot_file(filename):
@@ -355,42 +459,47 @@ class CBCollect(Source):
         * couchbase.log: extracted if not present
         :return: the name of the cbcollect directory into which files will be extracted
         """
-        root = zipfile.Path(zip_file)
-        root_dir = None
-        for p in root.iterdir():
-            if CBCollect.is_cbcollect_dir(p):
-                snapshot_exists = CBCollect.snapshot_dir_exists(pathlib.Path(p.name))
-                logging.debug("{}/stats_snapshot exists: {}".format(p.name,
-                                                                    snapshot_exists))
-                root_dir = p.name
-                extracting = False
-                for item in zip_file.infolist():
-                    item_path = path.join(*item.filename.split('/'))
-                    should_extract = False
-                    if CBCollect.is_stats_snapshot_file(item.filename):
-                        should_extract = not snapshot_exists
-                    elif item.filename.endswith(COUCHBASE_LOG):
-                        should_extract = not path.exists(item_path)
-                    if should_extract:
-                        logging.debug("zipfile item:{}, exists:{}".format(
-                            item_path, path.exists(item_path)))
-                        if not extracting:
-                            extracting = True
-                            logging.info('extracting stats, couchbase.log from cbcollect'
-                                         ' zip:{}'
-                                         .format(zip_file.filename))
-                        zip_file.extract(item)
+        # The cbcollect in the zip is identified by name, not by whether it
+        # holds a stats_snapshot: a cbcollect captured before Prometheus has
+        # none in the zip - the heartbeat backfill creates it on disk instead.
+        # Name is what find_cbcollect_dirs matches on disk, so the two agree.
+        root_dir = CBCollect.find_dir_in_zip(zip_file)
+        if root_dir is not None:
+            snapshot_exists = CBCollect.snapshot_dir_exists(pathlib.Path(root_dir))
+            logging.debug("{}/stats_snapshot exists: {}".format(root_dir,
+                                                                snapshot_exists))
+            extracting = False
+            for item in zip_file.infolist():
+                item_path = path.join(*item.filename.split('/'))
+                should_extract = False
+                if CBCollect.is_stats_snapshot_file(item.filename):
+                    should_extract = not snapshot_exists
+                elif item.filename.endswith(COUCHBASE_LOG):
+                    should_extract = not path.exists(item_path)
+                if should_extract:
+                    logging.debug("zipfile item:{}, exists:{}".format(
+                        item_path, path.exists(item_path)))
+                    if not extracting:
+                        extracting = True
+                        logging.info('extracting stats, couchbase.log from cbcollect'
+                                     ' zip:{}'
+                                     .format(zip_file.filename))
+                    zip_file.extract(item)
         return root_dir
 
     @staticmethod
-    def try_get_data_source_names(cbcollect_dirs, pattern, name_format):
+    def try_get_data_source_names(cbcollect_dirs, make_name):
+        """
+        Names each cbcollect by applying make_name to the parsed parts of its
+        directory name, falling back to the directory name itself where it
+        doesn't parse. Returns None if the names aren't unique.
+        :type make_name: callable taking a CBCollectDirName, returning a string
+        :rtype: list of strings, or None
+        """
         data_sources = []
         for cbcollect in cbcollect_dirs:
-            m = re.match(pattern, cbcollect)
-            name = cbcollect
-            if m:
-                name = name_format.format(*m.groups())
-            data_sources.append(name)
+            parsed = CBCollect.parse_dir_name(cbcollect)
+            data_sources.append(make_name(parsed) if parsed else cbcollect)
         if len(set(data_sources)) == len(data_sources):
             return data_sources
         return None
@@ -408,10 +517,15 @@ class CBCollect(Source):
         :rtype: list of names of data sources; if cbcollect_dirs contains no duplicates the
                 returned list is guaranteed to also contain no duplicates
         """
-        regex = re.compile(r'cbcollect_info_ns_(\d+)@(.*)_(\d+)-(\d+)')
-        formats = ['{1}', 'ns_{0}@{1}', '{1}-{2}-{3}', 'ns_{0}-{1}-{2}-{3}']
-        for fmt in formats:
-            result = CBCollect.try_get_data_source_names(cbcollect_dirs, regex, fmt)
+        # Progressively more of the directory name, stopping at the first that
+        # names every cbcollect uniquely.
+        namers = [lambda p: p.host,
+                  lambda p: p.node,
+                  lambda p: '{}-{}-{}'.format(p.host, p.date, p.time),
+                  lambda p: '{}_{}-{}-{}-{}'.format(p.prefix, p.index, p.host,
+                                                    p.date, p.time)]
+        for make_name in namers:
+            result = CBCollect.try_get_data_source_names(cbcollect_dirs, make_name)
             if result:
                 return result
         return cbcollect_dirs

--- a/promtimer/cbstats.py
+++ b/promtimer/cbstats.py
@@ -37,6 +37,7 @@ import util
 
 COUCHBASE_LOG = 'couchbase.log'
 DIAG_LOG = 'diag.log'
+NS_SERVER_STATS_LOG = 'ns_server.stats.log'
 STATS_SNAPSHOT_DIR_NAME = 'stats_snapshot'
 CBCOLLECT_DIR_PREFIX = 'cbcollect_info'
 
@@ -531,8 +532,27 @@ class CBCollect(Source):
         return cbcollect_dirs
 
     @staticmethod
-    def get_stats_sources(base_port):
+    def get_stats_sources(base_port, heartbeat_mode=None):
+        """
+        Prepares the cbcollects in the working directory and returns a stats Source
+        for each.
+        :param base_port: the port of the first Prometheus instance to be started
+        :param heartbeat_mode: a heartbeat.HeartbeatMode controlling the
+                               ns_server.stats.log backfill; defaults to AUTO
+        :rtype: list of CBCollect
+        """
+        # Imported here rather than at module scope: heartbeat imports cbstats
+        # for the cbcollect-finding functions above.
+        import heartbeat
+
         result = []
+        # Backfill the ns_server.stats.log heartbeat into each cbcollect's
+        # stats_snapshot before the cbcollects are discovered below: a snapshot
+        # created here makes an old (pre-snapshot) cbcollect discoverable, and
+        # the heartbeat-only metrics land in the same datasources. Runs once per
+        # cbcollect (skipped when the manifest already exists); no-op without
+        # promtool.
+        heartbeat.maybe_backfill(Source.PROMETHEUS_BIN, heartbeat_mode)
         cbcollects = CBCollect.get_cbcollect_dirs()
         if len(cbcollects) == 0:
             if os.path.isdir(STATS_SNAPSHOT_DIR_NAME):

--- a/promtimer/heartbeat.py
+++ b/promtimer/heartbeat.py
@@ -1,0 +1,735 @@
+# Copyright (c) 2026 Couchbase, Inc All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Backfill the ns_doctor heartbeat (ns_server.stats.log) into each
+cbcollect's stats_snapshot as Prometheus TSDB blocks, so heartbeat-only
+metrics (Erlang memory breakdown, the /proc/meminfo anon/file split,
+per-process RSS/CPU, and PSI pressure for captures from before 7.2.4, which
+is where sys_pressure_* starts being scraped) appear in the same datasource
+as the snapshot stats. For a cbcollect that has no stats_snapshot at all (pre-7.0),
+this creates one, which makes the collect openable in Promtimer.
+
+The logs are read out of the cbcollect zip whenever there is one, the way
+CBCollect.operate_on_log_file already reads couchbase.log and diag.log, so
+working from a directory of downloaded zips needs no unzipping and a
+cbcollect that has been unzipped with its zip left in place is no different.
+Both logs are consumed as a stream (ns_server.stats.log is tens of MB,
+diag.log can be hundreds), so nothing large is held in memory or on disk.
+
+Cost model: the backfill runs ONCE per cbcollect. A heartbeat_blocks.txt
+manifest in the snapshot records the blocks written; when it exists the
+backfill is skipped entirely (a stat call), so re-opening a cbcollect stays
+as fast as it is today. --heartbeat=refresh replaces the blocks; the
+manifest also makes removal safe (native snapshot blocks are never listed).
+
+Metric names carry a heartbeat_ prefix, so they can never collide with real
+exposition names. Collection gaps of >= 2 minutes become explicit NaN
+samples so Grafana renders a break instead of repeating the last value
+through the query lookback window. Requires promtool (looked up next to the
+prometheus binary, then on PATH); without it the backfill is skipped with a
+log line and Promtimer behaves exactly as before.
+"""
+import concurrent.futures
+import contextlib
+import enum
+import io
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import zipfile
+from collections import defaultdict
+from datetime import datetime
+
+# Local Imports
+import cbstats
+
+
+class HeartbeatMode(enum.Enum):
+    """What the heartbeat backfill should do for a cbcollect that already has
+    backfilled blocks: leave them alone (the default: the parse then happens
+    once per cbcollect), regenerate them, or don't backfill at all."""
+    AUTO = 'auto'
+    SKIP = 'skip'
+    REFRESH = 'refresh'
+
+    def __str__(self):
+        return self.value
+
+
+MANIFEST = 'heartbeat_blocks.txt'
+
+# What a cbcollect holds and where: cbstats owns the layout, these are just
+# short local names for it.
+STATS_LOG = cbstats.NS_SERVER_STATS_LOG
+DIAG_LOG = cbstats.DIAG_LOG
+SNAPSHOT_DIR = cbstats.STATS_SNAPSHOT_DIR_NAME
+
+# Heartbeat cadence and the gap rule: >= 2min between a series' samples is a
+# collection gap; the NaN break is stamped one nominal interval after the
+# last real sample.
+INTERVAL_S = 60
+GAP_S = 120
+
+
+# ---------------------------------------------------------------------------
+# cbcollect file access: on disk, or streamed out of the zip when the
+# cbcollect hasn't been unzipped
+# ---------------------------------------------------------------------------
+
+@contextlib.contextmanager
+def open_binary(cbcollect_dir, zip_path, name):
+    """Binary handle on a file of a cbcollect: read out of the cbcollect
+    zip whenever there is one, as CBCollect.operate_on_log_file already
+    does for couchbase.log and diag.log, and off disk only for a cbcollect
+    with no zip beside it. Reading the zip regardless of what happens to
+    be extracted means a partly unzipped cbcollect needs no special case.
+    Raises the usual FileNotFoundError/KeyError when the file isn't
+    there."""
+    if zip_path:
+        with zipfile.ZipFile(zip_path) as z:
+            with z.open(cbstats.CBCollect.zip_member_path(cbcollect_dir,
+                                                          name)) as f:
+                yield f
+    else:
+        with open(os.path.join(cbcollect_dir, name), 'rb') as f:
+            yield f
+
+
+@contextlib.contextmanager
+def open_text(cbcollect_dir, zip_path, name):
+    """As open_binary, decoded as utf-8."""
+    with open_binary(cbcollect_dir, zip_path, name) as f:
+        yield io.TextIOWrapper(f, 'utf-8', errors='replace')
+
+
+# ---------------------------------------------------------------------------
+# stats.log (ns_doctor heartbeat) parser
+# ---------------------------------------------------------------------------
+
+_TS_RE = re.compile(
+    r'ns_doctor:\w+,('
+    r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?'
+    r'(?:[+-]\d{2}:\d{2}|Z)?)')
+
+
+def _parse_doctor_ts(ts_str):
+    """UTC epoch (float) from the dump's ISO timestamp, or None when the
+    line carries no UTC offset (very old logs)."""
+    try:
+        dt = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return None
+    return dt.timestamp()
+
+
+def _with_lookahead(lines):
+    """Yield (index, line, next_line) over lines, next_line None at the end.
+    A few of the dump's values sit on the line after their key, and the
+    lookahead keeps the parser streaming rather than holding the whole
+    stats.log in memory."""
+    prev = None
+    for i, line in enumerate(lines):
+        if prev is not None:
+            yield prev[0], prev[1], line
+        prev = (i, line)
+    if prev is not None:
+        yield prev[0], prev[1], None
+
+
+def parse_entries(lines):
+    """Parse a stats.log (ns_doctor dump), given an iterable of its lines,
+    into a list of per-(dump, node) dicts: node, ts_epoch, plus every stat
+    key (system_*, memory_*, <proc>_*, disk_*, meminfo_*). Stale node
+    statuses (same last_heard as the previous dump) are dropped."""
+    entries = []
+    heard = defaultdict(str)
+
+    current_entry = None
+    mode = None
+    current_process = None
+    current_ts_epoch = None
+    seen_ts = False
+
+    for i, line, next_line in _with_lookahead(lines):
+        if 'ns_doctor:debug,' in line:
+            m = _TS_RE.search(line)
+            if not m:
+                raise ValueError('invalid timestamp at line {}'.format(i))
+            current_ts_epoch = _parse_doctor_ts(m.group(1))
+            seen_ts = True
+
+        elif re.match(r"[\[ ]{'(?:ns_1@|n_\d+@)", line):
+            if not seen_ts:
+                raise ValueError(
+                    'node entry without timestamp at line {}'.format(i))
+            node_match = re.search(r"{'([^']+)'", line)
+            if not node_match:
+                raise ValueError('invalid node format at line {}'.format(i))
+            if current_entry:
+                entries.append(current_entry)
+            current_entry = {
+                'node': node_match.group(1),
+                'ts_epoch': current_ts_epoch,
+            }
+
+        elif 'last_heard' in line and current_entry:
+            m = re.search(r'{last_heard,([-]*[0-9]+)', line)
+            if m:
+                last_heard = m.group(1)
+                if heard[current_entry['node']] == last_heard:
+                    current_entry = None        # stale status: drop
+                else:
+                    heard[current_entry['node']] = last_heard
+
+        elif current_entry and '{system_stats,' in line:
+            mode = 'system_stats'
+        elif mode == 'system_stats':
+            m = re.search(r'\{([^,]+),([0-9.]+)\}', line)
+            if m:
+                name = m.group(1)
+                if (name == 'allocstall' or 'cpu' in name.lower()
+                        or 'cores' in name.lower()):
+                    current_entry['system_' + name] = float(m.group(2))
+            if ']}' in line:
+                mode = None
+
+        elif current_entry and '{memory_data,' in line:
+            m = re.search(
+                r'\{memory_data,\{(\d+),(\d+),\{([^,]+),(\d+)\}\}\}', line)
+            if m:
+                current_entry['memory_worst_pid'] = m.group(3)
+                current_entry['memory_worst_used'] = int(m.group(4))
+
+        elif current_entry and '{meminfo,' in line:
+            blob = line
+            if next_line is not None:
+                blob += next_line
+            for key, field in [
+                ('active_anon', r'Active\(anon\)'),
+                ('inactive_anon', r'Inactive\(anon\)'),
+                ('active_file', r'Active\(file\)'),
+                ('inactive_file', r'Inactive\(file\)'),
+                ('dirty', 'Dirty'),
+                ('writeback', 'Writeback'),
+                ('mem_available', 'MemAvailable'),
+                ('slab', 'Slab'),
+                ('sunreclaim', 'SUnreclaim'),
+                ('percpu', 'Percpu'),
+            ]:
+                m = re.search(field + r':\s*(\d+)\s*kB', blob)
+                if m:
+                    current_entry['meminfo_' + key] = int(m.group(1)) * 1024
+
+        elif current_entry and '{disk_data,' in line:
+            mode = 'disk_data'
+        elif mode == 'disk_data':
+            # Every mount disksup reports, whatever it is called: a data path
+            # is as likely to be /data2 or /mnt/data as /data.
+            m = re.search(r'\{("[^"]+"),(\d+),(\d+)\}', line)
+            if m:
+                disk = m.group(1)
+                current_entry['disk_{}_usage'.format(disk)] = int(m.group(3))
+                current_entry['disk_{}_capacity'.format(disk)] = \
+                    int(m.group(2))
+            if '}]}]}' in line:
+                mode = None
+
+        elif current_entry and '{system_memory_data,' in line:
+            mode = 'system_memory_data'
+        elif mode == 'system_memory_data':
+            m = re.search(r'\{([^,]+),(\d+)\}', line)
+            if m:
+                current_entry['system_' + m.group(1)] = int(m.group(2))
+            if ']}' in line:
+                mode = None
+
+        elif current_entry and '{memory,' in line:
+            mode = 'memory'
+        elif mode == 'memory':
+            m = re.search(r'\{([^,]+),(\d+)\}', line)
+            if m:
+                current_entry['memory_' + m.group(1)] = int(m.group(2))
+            if ']}' in line:
+                mode = None
+
+        elif (current_entry and '{processes_stats,' in line
+                and '{processes_stats,[]},' not in line
+                and next_line is not None):
+            if '<<' in next_line.strip():
+                mode = 'processes_stats_pre_7_2_4'
+            else:
+                mode = 'processes_stats_7_2_4'
+        elif mode == 'processes_stats_pre_7_2_4':
+            m = re.search(r'{<<"([\S]+)/([\S]+)">>,(\d*\.*\d+)}', line)
+            if m:
+                process, stat, value = m.groups()
+                try:
+                    value = int(value)
+                except ValueError:
+                    value = float(value)
+                current_entry['{}_{}'.format(process, stat)] = value
+            if '}]},' in line:
+                mode = None
+        elif mode == 'processes_stats_7_2_4':
+            m = re.search(r'\{([^,]+),$', line)
+            if m:
+                current_process = m.group(1).strip("'")
+            m = re.search(r'\{([^,]+),([0-9.]+)\}', line)
+            if m and current_process:
+                stat = m.group(1).strip("'")
+                current_entry['{}_{}'.format(current_process, stat)] = \
+                    float(m.group(2))
+            if '}]}]}' in line:
+                mode = None
+
+        elif current_entry and '_pressure' in line:
+            m = re.search(r'\{([\w]+)_pressure', line)
+            if m and next_line is not None:
+                ptype = m.group(1)
+                for kind in ('some', 'full'):
+                    km = re.search(
+                        kind + r' avg10=([0-9]+.[0-9]+) '
+                        'avg60=([0-9]+.[0-9]+) '
+                        'avg300=([0-9]+.[0-9]+) '
+                        'total=([0-9]+)',
+                        next_line)
+                    if km:
+                        pfx = 'system_{}_pressure_{}'.format(ptype, kind)
+                        current_entry[pfx + '_avg60'] = float(km.group(2))
+                        current_entry[pfx + '_total'] = int(km.group(4))
+
+    if current_entry:
+        entries.append(current_entry)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# diag.log pid -> process name map (for the worst-memory-consumer series).
+# diag.log embeds the collected logs and can run to hundreds of MB while
+# the process sections are a few MB, so the scan is a single forward pass
+# over chunks and only the bytes of a section get split into lines. That
+# also keeps the scan working against a zip member, which can be read
+# forwards but not seeked.
+# ---------------------------------------------------------------------------
+
+_SECTION_BYTES_RE = re.compile(rb'per_node_\w*processes\(')
+_SCAN_CHUNK = 8 << 20
+_OVERLAP = 64                   # >= the longest section marker
+_PROC_START_RE = re.compile(r'^\s*\{(<\d+\.\d+\.\d+>),')
+_NAME_RE = re.compile(r'\{registered_name,\s*([^}\]]+)\}')
+_INITCALL_RE = re.compile(r'\{initial_call,\s*\{([^}]+)\}\}')
+
+
+def _process_section_lines(stream):
+    """Yield the lines of diag.log's process-dump sections (the section
+    header and the blank line that ends a section are not yielded)."""
+    tail = b''
+    in_section = False
+    while True:
+        chunk = stream.read(_SCAN_CHUNK)
+        if not chunk:
+            break
+        buf = tail + chunk
+        if not in_section and not _SECTION_BYTES_RE.search(buf):
+            # Nothing of interest here: carry over only enough bytes for a
+            # marker straddling the chunk boundary.
+            tail = buf[-_OVERLAP:]
+            continue
+        lines = buf.split(b'\n')
+        tail = lines.pop()          # possibly-partial last line
+        for line in lines:
+            if in_section:
+                if not line.strip():    # sections end with a blank line
+                    in_section = False
+                else:
+                    yield line.decode('utf-8', 'replace')
+            elif _SECTION_BYTES_RE.search(line):
+                in_section = True
+    if in_section and tail.strip():
+        yield tail.decode('utf-8', 'replace')
+
+
+def pid_names(cbcollect_dir, zip_path=None):
+    """Best-effort {erlang_pid: name} from diag.log's process dump. Only
+    local pids (<0.x.y>) appear in the dump, and remote pids in the
+    heartbeat print with a nonzero node index, so a remote pid can never
+    match. Anonymous processes and pids that died before collection simply
+    stay unlabeled."""
+    names = {}
+
+    def collect(buf, pid):
+        if not buf or not pid:
+            return
+        text = '\n'.join(buf)
+        m = _NAME_RE.search(text)
+        name = m.group(1).strip() if m else None
+        if name in ('[]', ''):
+            name = None
+        if not name:
+            m = _INITCALL_RE.search(text)
+            name = m.group(1).strip() if m else None
+        if name and name not in (pid, '?'):
+            names[pid] = name
+
+    try:
+        with open_binary(cbcollect_dir, zip_path, DIAG_LOG) as f:
+            buf, buf_pid = [], None
+            for line in _process_section_lines(f):
+                m = _PROC_START_RE.match(line)
+                if m:
+                    collect(buf, buf_pid)
+                    buf, buf_pid = [line], m.group(1)
+                elif buf:
+                    buf.append(line)
+            collect(buf, buf_pid)
+    except (OSError, KeyError):     # no diag.log: the pids stay unlabeled
+        return {}
+    return names
+
+
+# ---------------------------------------------------------------------------
+# heartbeat entries -> OpenMetrics -> TSDB blocks
+# ---------------------------------------------------------------------------
+
+_OS_MEMORY_KINDS = (
+    'total_memory', 'free_memory', 'available_memory', 'system_total_memory',
+    'buffered_memory', 'cached_memory', 'shared_memory', 'largest_free',
+    'total_swap', 'free_swap')
+
+_PROC_SUFFIXES = {
+    '_mem_resident': ('heartbeat_process_resident_memory_bytes', 'gauge'),
+    '_mem_size': ('heartbeat_process_virtual_memory_bytes', 'gauge'),
+    '_cpu_utilization': ('heartbeat_process_cpu_percent', 'gauge'),
+    '_major_faults_raw': ('heartbeat_process_major_faults', 'counter'),
+    '_minor_faults_raw': ('heartbeat_process_minor_faults', 'counter'),
+    '_page_faults_raw': ('heartbeat_process_page_faults', 'counter'),
+}
+
+_PRESSURE_RE = re.compile(
+    r'^system_(cpu|memory|io)_pressure_(some|full)_(avg60|total)$')
+_DISK_RE = re.compile(r'^disk_"(.*)"_(usage|capacity)$')
+
+
+def _esc(v):
+    return str(v).replace('\\', '\\\\').replace('"', '\\"').replace(
+        '\n', '\\n')
+
+
+def _classify(key, value, entry):
+    """Map one parsed entry key/value to (family, type, labels, value), or
+    None for keys that don't translate to a metric."""
+    if not isinstance(value, (int, float)):
+        return None
+
+    m = _PRESSURE_RE.match(key)
+    if m:
+        resource, kind, which = m.groups()
+        if which == 'avg60':
+            return ('heartbeat_pressure_avg60_percent', 'gauge',
+                    {'resource': resource, 'kind': kind}, value)
+        return ('heartbeat_pressure_stall_microseconds', 'counter',
+                {'resource': resource, 'kind': kind}, value)
+
+    m = _DISK_RE.match(key)
+    if m:
+        mount, which = m.groups()
+        if which == 'usage':
+            return ('heartbeat_disk_usage_percent', 'gauge',
+                    {'mount': mount}, value)
+        return ('heartbeat_disk_capacity_bytes', 'gauge',
+                {'mount': mount}, value * 1024)    # disksup reports KB
+
+    if key == 'system_allocstall':
+        return ('heartbeat_allocstall', 'counter', {}, value)
+    if key == 'system_cpu_utilization_rate':
+        return ('heartbeat_cpu_utilization_percent', 'gauge', {}, value)
+    if key == 'system_cpu_stolen_rate':
+        return ('heartbeat_cpu_stolen_percent', 'gauge', {}, value)
+    if key == 'system_cpu_cores_available':
+        return ('heartbeat_cpu_cores_available', 'gauge', {}, value)
+
+    if key == 'memory_worst_used':
+        pid = entry.get('memory_worst_pid')
+        labels = {'pid': pid} if pid else {}
+        return ('heartbeat_erlang_worst_process_memory_bytes', 'gauge',
+                labels, value)
+
+    if key.startswith('meminfo_'):
+        return ('heartbeat_meminfo_bytes', 'gauge',
+                {'kind': key[len('meminfo_'):]}, value)
+
+    if key.startswith('system_'):
+        kind = key[len('system_'):]
+        if kind in _OS_MEMORY_KINDS:
+            return ('heartbeat_os_memory_bytes', 'gauge',
+                    {'kind': kind}, value)
+        return None
+
+    if key.startswith('memory_') and key != 'memory_worst_pid':
+        return ('heartbeat_erlang_memory_bytes', 'gauge',
+                {'type': key[len('memory_'):]}, value)
+
+    for suffix, (family, mtype) in _PROC_SUFFIXES.items():
+        if key.endswith(suffix):
+            return (family, mtype, {'proc': key[: -len(suffix)]}, value)
+
+    return None
+
+
+def to_openmetrics(entries, nodes=None, names=None):
+    """Render heartbeat entries as OpenMetrics text. Where consecutive
+    samples of a series are >= GAP_S apart (a collection gap), an explicit
+    NaN is written one interval after the last real sample, so Prometheus's
+    query lookback carries forward NaN and Grafana breaks the line instead
+    of repeating stale values. Returns (text, n_samples)."""
+    types = {}
+    series = defaultdict(lambda: defaultdict(list))
+
+    for e in entries:
+        ts = e.get('ts_epoch')
+        if ts is None:
+            continue
+        if nodes is not None and e['node'] not in nodes:
+            continue
+        for key, value in e.items():
+            got = _classify(key, value, e)
+            if not got:
+                continue
+            family, mtype, labels, val = got
+            labels = dict(labels, node=e['node'])
+            if (names
+                    and family == 'heartbeat_erlang_worst_process_memory_bytes'
+                    and labels.get('pid') in names):
+                labels['name'] = names[labels['pid']]
+            labelstr = ','.join(
+                '{}="{}"'.format(k, _esc(v))
+                for k, v in sorted(labels.items()))
+            types[family] = mtype
+            series[family][labelstr].append((ts, val))
+
+    lines = []
+    n = 0
+    for family in sorted(series):
+        mtype = types[family]
+        lines.append('# TYPE {} {}'.format(family, mtype))
+        name = family + '_total' if mtype == 'counter' else family
+        for labelstr in sorted(series[family]):
+            prev_ts = None
+            for ts, val in sorted(series[family][labelstr]):
+                if prev_ts is not None and ts - prev_ts >= GAP_S:
+                    lines.append('{}{{{}}} NaN {}'.format(
+                        name, labelstr, prev_ts + INTERVAL_S))
+                lines.append('{}{{{}}} {} {}'.format(name, labelstr, val, ts))
+                prev_ts = ts
+                n += 1
+    lines.append('# EOF')
+    return '\n'.join(lines) + '\n', n
+
+
+def _backfill_one(task):
+    """Worker: backfill one cbcollect, reading its logs out of the zip when
+    it hasn't been unzipped. Returns a status string."""
+    cbcollect_dir, zip_path, promtool = task
+    snapshot = os.path.join(cbcollect_dir, SNAPSHOT_DIR)
+    try:
+        if zip_path:
+            # Extract the cbcollect's own snapshot first: the backfill writes
+            # blocks into stats_snapshot, and the normal extraction skips a
+            # snapshot directory that already exists. This is the same call
+            # the cbcollect discovery makes later, and is a no-op then.
+            with zipfile.ZipFile(zip_path) as z:
+                cbstats.CBCollect.maybe_extract_from_zipfile(z)
+        with open_text(cbcollect_dir, zip_path, STATS_LOG) as f:
+            entries = parse_entries(f)
+        all_nodes = {e['node'] for e in entries}
+        # Every node's heartbeat describes the whole cluster, so restrict this
+        # cbcollect's to the node that captured it (named by the dir name):
+        # each Prometheus instance then serves its own node, as the snapshot
+        # beside it does. Backfill nothing at all when that node can't be
+        # identified - the panels don't put the node in the legend, so keeping
+        # every node's series would silently pass another node's memory off as
+        # this one's.
+        # Absolute, so a cbcollect given as '.' (Promtimer run inside an
+        # unzipped cbcollect) is named by its directory rather than by '.'.
+        parsed = cbstats.CBCollect.parse_dir_name(
+            os.path.abspath(cbcollect_dir))
+        # cbcollect_info builds the directory name from the node name but
+        # replaces ':' with '-', so an IPv6 node's name doesn't survive into
+        # it intact: match the log's node names the same way rather than
+        # expecting the directory to spell the node exactly.
+        matched = [n for n in sorted(all_nodes)
+                   if parsed and n.replace(':', '-') == parsed.node]
+        if len(matched) != 1:
+            return ('{}: not backfilled, cannot tell which node captured it:'
+                    ' the directory is not named for exactly one of the nodes'
+                    ' the heartbeat describes ({})'
+                    .format(cbcollect_dir,
+                            ', '.join(sorted(all_nodes)) or 'none'))
+        nodes = {matched[0]}
+        # names only adds a label, never changes the sample count, so get
+        # the count first and only pay for pid_names (a diag.log byte-scan)
+        # when there is data to enrich.
+        text, n = to_openmetrics(entries, nodes=nodes)
+        if n == 0:
+            return '{}: no exportable heartbeat samples'.format(cbcollect_dir)
+        names = pid_names(cbcollect_dir, zip_path)
+        text, n = to_openmetrics(entries, nodes=nodes, names=names)
+
+        os.makedirs(snapshot, exist_ok=True)
+        before = {d for d in os.listdir(snapshot)
+                  if os.path.isdir(os.path.join(snapshot, d))}
+        with tempfile.NamedTemporaryFile('w', suffix='.om.txt',
+                                         delete=False) as f:
+            om_path = f.name
+            f.write(text)
+        try:
+            subprocess.run(
+                [promtool, 'tsdb', 'create-blocks-from', 'openmetrics',
+                 om_path, snapshot],
+                check=True, capture_output=True, text=True)
+        finally:
+            os.unlink(om_path)
+        created = sorted(
+            {d for d in os.listdir(snapshot)
+             if os.path.isdir(os.path.join(snapshot, d))} - before)
+        with open(os.path.join(snapshot, MANIFEST), 'a') as f:
+            for ulid in created:
+                f.write(ulid + '\n')
+        return '{}: backfilled {} heartbeat samples'.format(cbcollect_dir, n)
+    except subprocess.CalledProcessError as e:
+        return '{}: promtool failed: {}'.format(
+            cbcollect_dir, (e.stderr or e.stdout or '').strip())
+    except Exception as e:
+        return '{}: heartbeat backfill failed: {}'.format(cbcollect_dir, e)
+
+
+def _undo(snapshot):
+    """Remove the blocks a previous backfill wrote (native snapshot blocks
+    are never in the manifest). Removes the snapshot dir itself if that
+    leaves it empty (it was created by the backfill)."""
+    manifest = os.path.join(snapshot, MANIFEST)
+    if not os.path.isfile(manifest):
+        return
+    with open(manifest) as f:
+        for ulid in f.read().split():
+            block = os.path.join(snapshot, ulid)
+            if os.path.isdir(block):
+                shutil.rmtree(block)
+    os.remove(manifest)
+    try:
+        os.rmdir(snapshot)
+    except OSError:
+        pass
+
+
+def find_promtool(prom_bin):
+    """promtool next to the prometheus binary, else on PATH, else None."""
+    if prom_bin:
+        cand = os.path.join(os.path.dirname(os.path.abspath(prom_bin)),
+                            'promtool')
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+    return shutil.which('promtool')
+
+
+def find_cbcollects():
+    """Every cbcollect in the working directory that carries an
+    ns_server.stats.log, as a sorted list of (cbcollect_dir, zip_path)
+    pairs. zip_path is the zip holding the cbcollect, or None for a
+    cbcollect with no zip beside it; a cbcollect that has been unzipped
+    with its zip left in place is still read from the zip, so how much of
+    it has been extracted doesn't matter. When two zips hold the same
+    cbcollect directory the first by name wins.
+
+    The zips and the directories are the ones cbcollect discovery considers,
+    so a cbcollect Promtimer would never open is never backfilled. What
+    makes one usable differs though: discovery wants a stats_snapshot,
+    which a pre-7.0 cbcollect has nowhere, while the backfill only wants an
+    ns_server.stats.log - and creates the snapshot."""
+    found = {}
+    for z in cbstats.CBCollect.find_candidate_zips():
+        try:
+            with zipfile.ZipFile(z) as zip_file:
+                cbcollect_dir = cbstats.CBCollect.find_dir_in_zip(zip_file)
+                if cbcollect_dir and cbstats.CBCollect.zip_member_path(
+                        cbcollect_dir, STATS_LOG) in zip_file.namelist():
+                    found.setdefault(cbcollect_dir, z)
+        except (OSError, zipfile.BadZipFile) as e:
+            logging.debug('not reading heartbeat from {}: {}'.format(z, e))
+    for d in cbstats.CBCollect.find_candidate_dirs():
+        if os.path.isfile(os.path.join(d, STATS_LOG)):
+            found.setdefault(d, None)
+    if not found and os.path.isfile(STATS_LOG):
+        # Nothing beside us and a heartbeat log right here: Promtimer is being
+        # run inside an unzipped cbcollect. CBCollect.get_stats_sources takes
+        # the same cbcollect as '.' on the same reasoning, testing for the
+        # stats_snapshot it needs where this tests for the log it needs.
+        found['.'] = None
+    return sorted(found.items())
+
+
+def maybe_backfill(prom_bin, mode=None):
+    """Backfill the heartbeat for every cbcollect in the working directory
+    that has an ns_server.stats.log, unzipped or still zipped. Runs BEFORE
+    cbcollect discovery so a snapshot created here makes an old
+    (pre-snapshot) collect discoverable. Skips cbcollects whose snapshot
+    already carries the manifest, so this costs a stat call per cbcollect
+    on every open after the first; HeartbeatMode.REFRESH replaces
+    previously backfilled blocks and HeartbeatMode.SKIP does nothing at
+    all. mode defaults to HeartbeatMode.AUTO."""
+    mode = mode or HeartbeatMode.AUTO
+    if mode is HeartbeatMode.SKIP:
+        return
+    cbcollects = find_cbcollects()
+    if mode is HeartbeatMode.REFRESH:
+        for cbcollect_dir, _ in cbcollects:
+            _undo(os.path.join(cbcollect_dir, SNAPSHOT_DIR))
+    todo = [(cbcollect_dir, zip_path)
+            for cbcollect_dir, zip_path in cbcollects
+            if not os.path.isfile(
+                os.path.join(cbcollect_dir, SNAPSHOT_DIR, MANIFEST))]
+    if not todo:
+        return
+    promtool = find_promtool(prom_bin)
+    if not promtool:
+        logging.info('heartbeat backfill skipped: promtool not found next '
+                     'to prometheus or on PATH (brew install prometheus)')
+        return
+    logging.info(
+        'backfilling ns_server.stats.log heartbeat for {} cbcollect(s). '
+        'This runs once per cbcollect (parsed in parallel) and is skipped '
+        'on later opens. '
+        'To skip it entirely, pass --heartbeat=skip. '
+        'To regenerate after changing the heartbeat parser, pass '
+        '--heartbeat=refresh.'.format(len(todo)))
+    start = time.perf_counter()
+    tasks = [(cbcollect_dir, zip_path, promtool)
+             for cbcollect_dir, zip_path in todo]
+    workers = min(len(tasks), os.cpu_count() or 1)
+    if workers > 1:
+        with concurrent.futures.ProcessPoolExecutor(
+                max_workers=workers) as ex:
+            results = list(ex.map(_backfill_one, tasks))
+    else:
+        results = [_backfill_one(t) for t in tasks]
+    for r in results:
+        logging.info(r)
+    logging.info('heartbeat backfill done: {} cbcollect(s) in {:.0f}s'.format(
+        len(todo), time.perf_counter() - start))

--- a/promtimer/promtimer.py
+++ b/promtimer/promtimer.py
@@ -31,6 +31,7 @@ import annotations
 import backupstats
 import cbstats
 import dashboard
+import heartbeat
 import templating
 import util
 
@@ -268,7 +269,8 @@ def make_stats_sources(
         user: str | None,
         password: str | None,
         backup_archive_path: str | None,
-        cbmstatparser_path: str):
+        cbmstatparser_path: str,
+        heartbeat_mode: heartbeat.HeartbeatMode):
     live_cluster = cluster or nodes
     if live_cluster:
         if nodes:
@@ -294,7 +296,8 @@ def make_stats_sources(
             prometheus_base_port
         )
     else:
-        stats_sources = cbstats.CBCollect.get_stats_sources(prometheus_base_port)
+        stats_sources = cbstats.CBCollect.get_stats_sources(prometheus_base_port,
+                                                            heartbeat_mode)
         if not stats_sources:
             sys.exit(1)
         times = cbstats.CBCollect.compute_min_and_max_times(stats_sources)
@@ -356,6 +359,7 @@ def run_promtimer(
         buckets: list[str],
         backup_archive_path: str | None,
         cbmstatparser_path: str,
+        heartbeat_mode: heartbeat.HeartbeatMode,
         refresh: str,
         dont_open_browser: bool):
 
@@ -369,7 +373,8 @@ def run_promtimer(
             user=user,
             password=password,
             backup_archive_path=backup_archive_path,
-            cbmstatparser_path=cbmstatparser_path)
+            cbmstatparser_path=cbmstatparser_path,
+            heartbeat_mode=heartbeat_mode)
 
     # determine timezone, list of buckets, refresh interval, etc
     timezone_override = os.environ.get('GRAFANA_TZ', '')
@@ -476,6 +481,17 @@ def parse_args_validate_and_run():
                              'for; if this option is provided, auto-detection of the '
                              'buckets by parsing couchbase.log (or by querying a running '
                              'Couchbase Server node directly) will be skipped')
+    parser.add_argument('--heartbeat', dest='heartbeat',
+                        type=heartbeat.HeartbeatMode,
+                        choices=list(heartbeat.HeartbeatMode),
+                        default=heartbeat.HeartbeatMode.AUTO,
+                        help='what to do about backfilling ns_server.stats.log '
+                             'heartbeat metrics into the stats snapshots: '
+                             '"auto" (the default) backfills once per cbcollect, '
+                             'on first open only; "skip" doesn\'t backfill; '
+                             '"refresh" discards and regenerates the backfilled '
+                             'metrics, which is needed to pick up changes to the '
+                             'heartbeat parser')
     parser.add_argument('--dont-open-browser', dest='dont_open_browser', default=False,
                         action='store_true',
                         help='don\'t open browser tab automatically on start')
@@ -568,6 +584,7 @@ def parse_args_validate_and_run():
         buckets=args.buckets.split(',') if args.buckets else [],
         backup_archive_path=args.backup_archive_path,
         cbmstatparser_path=args.cbmstatparser_bin if args.cbmstatparser_bin else CBMSTATPARSER_BIN,
+        heartbeat_mode=args.heartbeat,
         refresh=args.refresh if args.refresh else '',
         dont_open_browser=args.dont_open_browser)
 


### PR DESCRIPTION
When run against cbcollects, parse each cbcollect's ns_server.stats.log (the ns_doctor heartbeat, roughly one sample per minute) and backfill it into that cbcollect's stats_snapshot as Prometheus TSDB blocks via promtool. The heartbeat-only metrics (Erlang memory breakdown, PSI pressure on pre-7.2.4 captures, the /proc/meminfo anon/file LRU split and reclaim-health fields, disk usage) then appear in the same per-node datasources as the snapshot stats, on a new 'NS Server log-derived' dashboard. For a cbcollect that has no stats_snapshot at all, the backfill creates one, which makes the collect openable in Promtimer.

Every series is whole-node: the ns_doctor heartbeat reads /proc and carries no cgroup view, so the PSI panel titles are tagged host and the description points to Node Overview for the Couchbase-slice (cgroup) view of a node.

These metrics cover a shorter window than the snapshot stats. ns_server's stats.log sink takes the default disk_sink_opts - 40 MiB per file, 10 rotations, compressed - and cbcollect concatenates every retained generation into ns_server.stats.log, so the heartbeat reaches back however long that much ns_doctor output happens to be. Each dump covers every node and bucket, so the span narrows as a cluster grows: a couple of days is typical, less on a large one.

The backfill runs once per cbcollect: a heartbeat_blocks.txt manifest records the created blocks and its presence skips the work on later opens, so reopening stays as fast as today. --refresh-heartbeat replaces the blocks, --no-heartbeat disables the feature. Blocks are additive and the manifest never lists native snapshot blocks, so the original data is untouched and removal is safe.

Requires promtool (found next to the prometheus binary or on PATH); without it the backfill is skipped with a log line. Note the server install's bin directory ships prometheus but not promtool.

Metric names carry a heartbeat_ prefix so they do not collide.
Collection gaps of two minutes or more become explicit NaN samples so panels show a break instead of repeating stale values.
The worst-memory-consumer series carries a best-effort process name resolved from diag.log's process dump.