### PR TITLE
Heartbeat: end each series with a NaN, plot the worst pid as dots

### DIFF
--- a/dashboards/node-log-derived.json
+++ b/dashboards/node-log-derived.json
@@ -267,10 +267,30 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes"
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "points",
+            "pointSize": 6,
+            "showPoints": "always",
+            "lineWidth": 0
+          }
         }
       },
-      "description": "The largest single Erlang process on the node by allocated bytes, as memsup's get_memory_data() reports it, labelled with its pid and, where diag.log's process dump names it, its registered name or initial call.\n\nThe largest process is re-picked at every sample, so a series starts and stops as the winner changes.\n\nmemsup returns the result of its latest memory check rather than running a fresh one, so a sample can lag its timestamp by up to the check interval - one minute by default. The value is undefined where memsup is configured not to collect process data (memsup_system_only)."
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["count"],
+          "sortBy": "Count",
+          "sortDesc": true,
+          "limit": 3
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "description": "The largest single Erlang process on the node by allocated bytes, as memsup's get_memory_data() reports it, labelled with its pid and, where diag.log's process dump names it, its registered name or initial call. The legend counts the samples each pid won and lists the three most frequent; 'show all' opens the rest. Every pid is plotted whether or not it is in the legend - hover a dot to identify it.\n\nmemsup returns the result of its latest memory check rather than running a fresh one, so a sample can lag its timestamp by up to the check interval - one minute by default."
     },
     {
       "title": "Memory pressure - share of time stalled, avg60 (host)",

--- a/promtimer/heartbeat.py
+++ b/promtimer/heartbeat.py
@@ -498,7 +498,9 @@ def to_openmetrics(entries, nodes=None, names=None):
     samples of a series are >= GAP_S apart (a collection gap), an explicit
     NaN is written one interval after the last real sample, so Prometheus's
     query lookback carries forward NaN and Grafana breaks the line instead
-    of repeating stale values. Returns (text, n_samples)."""
+    of repeating stale values. Each series is terminated the same way, so
+    its final sample doesn't carry forward for the whole lookback window
+    either. Returns (text, n_samples)."""
     types = {}
     series = defaultdict(lambda: defaultdict(list))
 
@@ -539,6 +541,9 @@ def to_openmetrics(entries, nodes=None, names=None):
                 lines.append('{}{{{}}} {} {}'.format(name, labelstr, val, ts))
                 prev_ts = ts
                 n += 1
+            if prev_ts is not None:
+                lines.append('{}{{{}}} NaN {}'.format(
+                    name, labelstr, prev_ts + INTERVAL_S))
     lines.append('# EOF')
     return '\n'.join(lines) + '\n', n
 


### PR DESCRIPTION
memsup re-picks the largest Erlang process at every sample, so the series identity changes from one instant to the next. Drawing them as lines plots a frequent winner as a continuous trace it never had. ns_server's scripts/parse_stats_log.py plots the same field with plt.scatter for that reason. Draw points instead.

Put the per-pid sample count in the legend, sorted with the most frequent first and capped at three.

The count also showed that the samples were being over-reported. Promtimer runs Prometheus with a 600s lookback delta, so a sample is returned for ten minutes after its timestamp. to_openmetrics wrote an explicit NaN one interval after a sample where the next one was a collection gap away. Emit the same NaN one interval past the last sample of every series: the worst-pid panel is where it is visible, but until now every heartbeat series ended in a ten minute flat tail that no sample supported.